### PR TITLE
feat(game): add terrarium room view

### DIFF
--- a/components/game/CMakeLists.txt
+++ b/components/game/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "game.c"
+idf_component_register(SRCS "game.c" "room.c"
                         INCLUDE_DIRS "."
                         REQUIRES lvgl storage)

--- a/components/game/game.c
+++ b/components/game/game.c
@@ -2,6 +2,7 @@
 #include "lvgl.h"
 #include "storage.h"
 #include "esp_log.h"
+#include "room.h"
 #include <string.h>
 #include <stdlib.h>
 
@@ -35,6 +36,9 @@ static void btn_new_game_event(lv_event_t *e)
     if (!storage_save(SAVE_PATH, game_state, sizeof(reptile_t))) {
         ESP_LOGE(TAG, "Failed to save game");
     }
+
+    /* After creating a new game, open the room selection view */
+    room_show();
 }
 
 static void btn_resume_event(lv_event_t *e)

--- a/components/game/room.c
+++ b/components/game/room.c
@@ -1,0 +1,53 @@
+#include "room.h"
+#include "esp_log.h"
+#include <stdbool.h>
+#include <string.h>
+
+#define TAG "room"
+#define GRID_SIZE 5
+
+static bool occupied[GRID_SIZE][GRID_SIZE];
+
+typedef struct {
+    uint8_t x;
+    uint8_t y;
+} terrarium_ctx_t;
+
+static void terrarium_event_handler(lv_event_t *e)
+{
+    terrarium_ctx_t *ctx = lv_event_get_user_data(e);
+    if (!ctx) return;
+    if (occupied[ctx->y][ctx->x]) {
+        ESP_LOGW(TAG, "Terrarium %u,%u already occupied", ctx->x, ctx->y);
+        return;
+    }
+    occupied[ctx->y][ctx->x] = true;
+    lv_obj_t *btn = lv_event_get_target(e);
+    lv_obj_set_style_bg_color(btn, lv_palette_main(LV_PALETTE_GREEN), LV_PART_MAIN);
+    lv_obj_add_state(btn, LV_STATE_DISABLED);
+    ESP_LOGI(TAG, "Selected terrarium %u,%u", ctx->x, ctx->y);
+}
+
+void room_show(void)
+{
+    memset(occupied, 0, sizeof(occupied));
+    lv_obj_t *scr = lv_obj_create(NULL);
+    lv_scr_load(scr);
+
+    const int size = 60;
+    const int spacing = 10;
+    static terrarium_ctx_t ctx[GRID_SIZE][GRID_SIZE];
+
+    for (int y = 0; y < GRID_SIZE; ++y) {
+        for (int x = 0; x < GRID_SIZE; ++x) {
+            lv_obj_t *btn = lv_btn_create(scr);
+            lv_obj_set_size(btn, size, size);
+            lv_obj_align(btn, LV_ALIGN_TOP_LEFT,
+                         x * (size + spacing) + spacing,
+                         y * (size + spacing) + spacing);
+            ctx[y][x].x = x;
+            ctx[y][x].y = y;
+            lv_obj_add_event_cb(btn, terrarium_event_handler, LV_EVENT_CLICKED, &ctx[y][x]);
+        }
+    }
+}

--- a/components/game/room.h
+++ b/components/game/room.h
@@ -1,0 +1,11 @@
+#ifndef ROOM_H
+#define ROOM_H
+
+#include "lvgl.h"
+
+/**
+ * @brief Create and display the terrarium selection grid.
+ */
+void room_show(void);
+
+#endif // ROOM_H


### PR DESCRIPTION
## Summary
- add room module to display a 5x5 interactive terrarium grid
- allow touch selection of free terrariums
- open terrarium grid after starting a new game

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c74525d430832396218c044d507526