### PR TITLE
feat(game): add terrarium module

### DIFF
--- a/components/game/CMakeLists.txt
+++ b/components/game/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "game.c" "room.c"
-                        INCLUDE_DIRS "."
+idf_component_register(SRCS "game.c" "room.c" "terrarium/terrarium.c"
+                        INCLUDE_DIRS "." "terrarium"
                         REQUIRES lvgl storage)

--- a/components/game/game.c
+++ b/components/game/game.c
@@ -3,6 +3,7 @@
 #include "storage.h"
 #include "esp_log.h"
 #include "room.h"
+#include "terrarium.h"
 #include <string.h>
 #include <stdlib.h>
 
@@ -12,6 +13,7 @@ typedef struct {
     char species[32];
     float temperature;
     float humidity;
+    float uv_index;
 } reptile_t;
 
 static lv_obj_t *main_menu;
@@ -33,6 +35,9 @@ static void btn_new_game_event(lv_event_t *e)
     strncpy(game_state->species, "Serpent", sizeof(game_state->species) - 1);
     game_state->temperature = 28.0f;
     game_state->humidity = 60.0f;
+    game_state->uv_index = 3.0f;
+    terrarium_update_environment(game_state->temperature, game_state->humidity,
+                                 game_state->uv_index);
     if (!storage_save(SAVE_PATH, game_state, sizeof(reptile_t))) {
         ESP_LOGE(TAG, "Failed to save game");
     }
@@ -55,8 +60,10 @@ static void btn_resume_event(lv_event_t *e)
         ESP_LOGE(TAG, "No saved game");
         return;
     }
-    ESP_LOGI(TAG, "Loaded %s T=%.1f H=%.1f", game_state->species,
-             game_state->temperature, game_state->humidity);
+    terrarium_update_environment(game_state->temperature, game_state->humidity,
+                                 game_state->uv_index);
+    ESP_LOGI(TAG, "Loaded %s T=%.1f H=%.1f UV=%.1f", game_state->species,
+             game_state->temperature, game_state->humidity, game_state->uv_index);
 }
 
 static void btn_settings_event(lv_event_t *e)

--- a/components/game/terrarium/terrarium.c
+++ b/components/game/terrarium/terrarium.c
@@ -1,0 +1,36 @@
+#include "terrarium.h"
+#include "esp_log.h"
+#include <string.h>
+
+#define TAG "terrarium"
+#define MAX_ITEMS 16
+#define ITEM_NAME_LEN 32
+
+static char items[MAX_ITEMS][ITEM_NAME_LEN];
+static size_t item_count;
+
+static struct {
+    float temperature;
+    float humidity;
+    float uv_index;
+} environment;
+
+bool terrarium_add_item(const char *item)
+{
+    if (!item || item_count >= MAX_ITEMS) {
+        return false;
+    }
+    strncpy(items[item_count], item, ITEM_NAME_LEN - 1);
+    items[item_count][ITEM_NAME_LEN - 1] = '\0';
+    item_count++;
+    ESP_LOGI(TAG, "Added item: %s", item);
+    return true;
+}
+
+void terrarium_update_environment(float temperature, float humidity, float uv_index)
+{
+    environment.temperature = temperature;
+    environment.humidity = humidity;
+    environment.uv_index = uv_index;
+    ESP_LOGI(TAG, "Environment updated T=%.1fC H=%.1f%% UV=%.1f", temperature, humidity, uv_index);
+}

--- a/components/game/terrarium/terrarium.h
+++ b/components/game/terrarium/terrarium.h
@@ -1,0 +1,28 @@
+#ifndef TERRARIUM_H
+#define TERRARIUM_H
+
+#include <stdbool.h>
+
+/**
+ * @brief Add an item to the terrarium inventory.
+ *
+ * Stores the item name in an internal list for later reference.
+ *
+ * @param item Name of the item to add.
+ * @return true on success, false if the list is full or item is NULL.
+ */
+bool terrarium_add_item(const char *item);
+
+/**
+ * @brief Synchronise environment parameters with the hosted reptile.
+ *
+ * Updates the temperature, humidity and UV index of the terrarium to match
+ * the requirements of the reptile currently housed.
+ *
+ * @param temperature Target temperature in Celsius.
+ * @param humidity Target relative humidity in percent.
+ * @param uv_index Target UV index.
+ */
+void terrarium_update_environment(float temperature, float humidity, float uv_index);
+
+#endif // TERRARIUM_H


### PR DESCRIPTION
## Summary
- add terrarium submodule for item inventory and environment sync
- extend reptile data with UV index and propagate environment updates

## Testing
- `idf.py --version` *(command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c746c9b86083239a1f0e90b586c38d