### PR TITLE
feat: add basic economy system

### DIFF
--- a/components/game/CMakeLists.txt
+++ b/components/game/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "game.c" "room.c" "terrarium/terrarium.c" "reptiles/reptiles.c"
+idf_component_register(SRCS "game.c" "room.c" "economy.c" "terrarium/terrarium.c" "reptiles/reptiles.c"
                         INCLUDE_DIRS "." "terrarium" "reptiles"
                         REQUIRES lvgl storage)

--- a/components/game/economy.c
+++ b/components/game/economy.c
@@ -1,0 +1,68 @@
+#include "economy.h"
+
+#include <stddef.h>
+
+/* Economic parameters */
+#define WEEKLY_CREDIT       100.0f
+#define FOOD_COST_PER_DAY   10.0f
+#define ELECTRICITY_COST    5.0f
+#define VETERINARY_COST     2.0f
+#define EQUIPMENT_COST      1.0f
+
+/* Wellbeing adjustment thresholds */
+#define WELLBEING_MAX       100.0f
+#define WELLBEING_MIN       0.0f
+
+static void economy_apply_wellbeing(economy_t *eco)
+{
+    if (!eco) {
+        return;
+    }
+
+    if (eco->budget < 0.0f) {
+        eco->wellbeing -= 5.0f;
+    } else if (eco->budget < 50.0f) {
+        eco->wellbeing -= 1.0f;
+    } else if (eco->budget > 200.0f) {
+        eco->wellbeing += 1.0f;
+    }
+
+    if (eco->wellbeing > WELLBEING_MAX) {
+        eco->wellbeing = WELLBEING_MAX;
+    } else if (eco->wellbeing < WELLBEING_MIN) {
+        eco->wellbeing = WELLBEING_MIN;
+    }
+}
+
+void economy_init(economy_t *eco, float initial_budget, float initial_wellbeing)
+{
+    if (!eco) {
+        return;
+    }
+
+    eco->day = 0;
+    eco->budget = initial_budget;
+    eco->wellbeing = initial_wellbeing;
+}
+
+void economy_next_day(economy_t *eco)
+{
+    if (!eco) {
+        return;
+    }
+
+    eco->day++;
+
+    /* Weekly automatic credit */
+    if (eco->day % 7 == 1) {
+        eco->budget += WEEKLY_CREDIT;
+    }
+
+    /* Daily expenses */
+    eco->budget -= FOOD_COST_PER_DAY;
+    eco->budget -= ELECTRICITY_COST;
+    eco->budget -= VETERINARY_COST;
+    eco->budget -= EQUIPMENT_COST;
+
+    economy_apply_wellbeing(eco);
+}

--- a/components/game/economy.h
+++ b/components/game/economy.h
@@ -1,0 +1,34 @@
+#ifndef ECONOMY_H
+#define ECONOMY_H
+
+#include <stdint.h>
+
+/**
+ * @brief Game economy state.
+ */
+typedef struct {
+    uint32_t day;      /**< Current in-game day counter. */
+    float budget;      /**< Player budget in credits. */
+    float wellbeing;   /**< Reptile wellbeing score [0,100]. */
+} economy_t;
+
+/**
+ * @brief Initialise the economy system.
+ *
+ * @param eco Economy instance to initialise.
+ * @param initial_budget Starting credits for the player.
+ * @param initial_wellbeing Initial wellbeing score.
+ */
+void economy_init(economy_t *eco, float initial_budget, float initial_wellbeing);
+
+/**
+ * @brief Advance the simulation by one day.
+ *
+ * Handles weekly income, daily expenses and adjusts wellbeing according to
+ * the remaining budget.
+ *
+ * @param eco Economy instance to update.
+ */
+void economy_next_day(economy_t *eco);
+
+#endif // ECONOMY_H


### PR DESCRIPTION
## Summary
- add economy module tracking budget, days and wellbeing
- credit applied weekly and daily expenses deducted
- integrate economy component into build system

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7489743b0832389f23d59a2b78593