### PR TITLE
Add accelerated environment simulation for terrariums

### DIFF
--- a/components/game/CMakeLists.txt
+++ b/components/game/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "game.c" "room.c" "economy.c" "terrarium/terrarium.c" "reptiles/reptiles.c"
+idf_component_register(SRCS "game.c" "room.c" "economy.c" "environment.c" "terrarium/terrarium.c" "reptiles/reptiles.c"
                         INCLUDE_DIRS "." "terrarium" "reptiles"
                         REQUIRES lvgl storage)

--- a/components/game/environment.c
+++ b/components/game/environment.c
@@ -1,0 +1,57 @@
+#include "environment.h"
+#include "terrarium.h"
+#include "esp_timer.h"
+#include "esp_log.h"
+#include <math.h>
+
+#define TAG "environment"
+
+/* Real-time acceleration: 1 second represents 1 hour of game time */
+#define HOURS_PER_SEC 1
+
+/* Profile for terrarium environment (day and night conditions) */
+typedef struct {
+    float day_temp;      /**< Daytime temperature in Celsius */
+    float night_temp;    /**< Nighttime temperature in Celsius */
+    float day_humidity;  /**< Daytime relative humidity in percent */
+    float night_humidity;/**< Nighttime relative humidity in percent */
+    float day_uv;        /**< Daytime UV index */
+} env_profile_t;
+
+static env_profile_t profiles[] = {
+    {30.0f, 25.0f, 60.0f, 80.0f, 5.0f}, /* Default terrarium */
+};
+
+static esp_timer_handle_t env_timer;
+static int64_t start_time;
+
+/* Compute environment and synchronise with terrarium */
+static void environment_tick(void *arg)
+{
+    (void)arg;
+    int64_t now = esp_timer_get_time();
+    float sim_hours = ((now - start_time) / 1000000.0f) * HOURS_PER_SEC; /* Simulated hours */
+    float day_progress = fmodf(sim_hours, 24.0f);                      /* 0..24 */
+    float ratio = 0.5f - 0.5f * cosf(day_progress / 24.0f * 2.0f * (float)M_PI); /* 0 night,1 noon */
+
+    size_t count = sizeof(profiles) / sizeof(profiles[0]);
+    for (size_t i = 0; i < count; ++i) {
+        const env_profile_t *p = &profiles[i];
+        float temp = p->night_temp + (p->day_temp - p->night_temp) * ratio;
+        float humidity = p->night_humidity + (p->day_humidity - p->night_humidity) * ratio;
+        float uv = p->day_uv * ratio; /* UV drops to 0 at night */
+        terrarium_update_environment(temp, humidity, uv);
+    }
+}
+
+void environment_init(void)
+{
+    start_time = esp_timer_get_time();
+    const esp_timer_create_args_t args = {
+        .callback = &environment_tick,
+        .name = "env"
+    };
+    ESP_ERROR_CHECK(esp_timer_create(&args, &env_timer));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(env_timer, 1000 * 1000)); /* Update every second */
+    ESP_LOGI(TAG, "Accelerated day/night cycle started");
+}

--- a/components/game/environment.h
+++ b/components/game/environment.h
@@ -1,0 +1,9 @@
+#ifndef ENVIRONMENT_H
+#define ENVIRONMENT_H
+
+/**
+ * @brief Start accelerated day/night environment simulation.
+ */
+void environment_init(void);
+
+#endif // ENVIRONMENT_H

--- a/components/game/game.c
+++ b/components/game/game.c
@@ -5,6 +5,7 @@
 #include "room.h"
 #include "terrarium.h"
 #include "reptiles.h"
+#include "environment.h"
 #include "esp_heap_caps.h"
 #include <string.h>
 #include <stdlib.h>
@@ -95,6 +96,7 @@ void game_init(void)
     if (!reptiles_load()) {
         ESP_LOGE(TAG, "Failed to load reptile data");
     }
+    environment_init();
     ESP_LOGI(TAG, "Game initialized");
 }
 


### PR DESCRIPTION
## Summary
- simulate day/night cycle and environmental variations
- periodically update terrarium conditions via esp-timer
- start environment management during game initialization

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c749e72ff88323a7ebf52b431cf79b