### PR TITLE
feat(touch): add gesture detection for drag and pinch

### DIFF
--- a/components/touch_gt911/CMakeLists.txt
+++ b/components/touch_gt911/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "touch_gt911.c"
+idf_component_register(SRCS "touch_gt911.c" "input_gestures.c"
                         INCLUDE_DIRS "."
                         REQUIRES lvgl driver)

--- a/components/touch_gt911/input_gestures.c
+++ b/components/touch_gt911/input_gestures.c
@@ -1,0 +1,43 @@
+#include "input_gestures.h"
+#include <math.h>
+
+typedef struct {
+    lv_point_t last_point;
+    int last_distance;
+    size_t last_touch_cnt;
+} gesture_state_t;
+
+static gesture_state_t gstate;
+
+void input_gestures_update(const lv_point_t *points, size_t touch_cnt)
+{
+    lv_obj_t *act = lv_scr_act();
+
+    if (touch_cnt == 1) {
+        if (gstate.last_touch_cnt == 1) {
+            lv_point_t delta;
+            delta.x = points[0].x - gstate.last_point.x;
+            delta.y = points[0].y - gstate.last_point.y;
+            if (delta.x != 0 || delta.y != 0) {
+                lv_event_send(act, LV_EVENT_USER_1, &delta);
+            }
+        }
+        gstate.last_point = points[0];
+    } else if (touch_cnt >= 2) {
+        int dx = points[0].x - points[1].x;
+        int dy = points[0].y - points[1].y;
+        int dist = (int)sqrtf((float)(dx * dx + dy * dy));
+        if (gstate.last_touch_cnt >= 2) {
+            int diff = dist - gstate.last_distance;
+            if (diff != 0) {
+                lv_event_send(act, LV_EVENT_USER_2, &diff);
+            }
+        }
+        gstate.last_distance = dist;
+    }
+
+    gstate.last_touch_cnt = touch_cnt;
+    if (touch_cnt == 0) {
+        gstate.last_distance = 0;
+    }
+}

--- a/components/touch_gt911/input_gestures.h
+++ b/components/touch_gt911/input_gestures.h
@@ -1,0 +1,17 @@
+#ifndef INPUT_GESTURES_H
+#define INPUT_GESTURES_H
+
+#include "lvgl.h"
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void input_gestures_update(const lv_point_t *points, size_t touch_cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // INPUT_GESTURES_H


### PR DESCRIPTION
## Summary
- add generic gesture processor for GT911 touch controller
- compute drag delta and pinch distance
- forward custom LVGL events to active screen

## Testing
- `idf.py build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c74cb7188c8323880f5a73fe81e3c8