### PR TITLE
Align LVGL RGB pins with Waveshare schematic

### DIFF
--- a/components/lvgl_port/lvgl_port.cpp
+++ b/components/lvgl_port/lvgl_port.cpp
@@ -1,47 +1,52 @@
 #include "lvgl_port.h"
-#include <lvgl.h>
-#include <LovyanGFX.hpp>
 #include "esp_heap_caps.h"
 #include "esp_memory_utils.h"
+#include <LovyanGFX.hpp>
 #include <assert.h>
+#include <lvgl.h>
 
 class LGFX : public lgfx::LGFX_Device {
   lgfx::Panel_RGB _panel;
   lgfx::Bus_RGB _bus;
+
 public:
   LGFX() {
     {
       auto cfg = _bus.config();
       cfg.panel_width = 1024;
       cfg.panel_height = 600;
-      cfg.pin_hsync = 46;
-      cfg.pin_vsync = 3;
-      cfg.pin_de = 5;
-      cfg.pin_pclk = 7;
-      cfg.pin_r0 = 1;
-      cfg.pin_r1 = 2;
-      cfg.pin_r2 = 42;
-      cfg.pin_r3 = 41;
-      cfg.pin_r4 = 40;
-      cfg.pin_r5 = -1;
-      cfg.pin_r6 = -1;
-      cfg.pin_r7 = -1;
-      cfg.pin_g0 = 39;
-      cfg.pin_g1 = 0;
-      cfg.pin_g2 = 45;
-      cfg.pin_g3 = 48;
-      cfg.pin_g4 = 47;
-      cfg.pin_g5 = 21;
-      cfg.pin_g6 = -1;
-      cfg.pin_g7 = -1;
-      cfg.pin_b0 = 14;
-      cfg.pin_b1 = 38;
-      cfg.pin_b2 = 18;
-      cfg.pin_b3 = 17;
-      cfg.pin_b4 = 10;
-      cfg.pin_b5 = -1;
-      cfg.pin_b6 = -1;
-      cfg.pin_b7 = -1;
+      cfg.pin_hsync = 46; // HSYNC
+      cfg.pin_vsync = 3;  // VSYNC
+      cfg.pin_de = 5;     // DE
+      cfg.pin_pclk = 7;   // PCLK
+
+      // RGB565 mapping according to Waveshare ESP32-S3 Touch LCD 7B schematic
+      cfg.pin_r0 = -1;
+      cfg.pin_r1 = -1;
+      cfg.pin_r2 = -1;
+      cfg.pin_r3 = 1;  // R3
+      cfg.pin_r4 = 2;  // R4
+      cfg.pin_r5 = 42; // R5
+      cfg.pin_r6 = 41; // R6
+      cfg.pin_r7 = 40; // R7
+
+      cfg.pin_g0 = -1;
+      cfg.pin_g1 = -1;
+      cfg.pin_g2 = 39; // G2
+      cfg.pin_g3 = 0;  // G3
+      cfg.pin_g4 = 45; // G4
+      cfg.pin_g5 = 48; // G5
+      cfg.pin_g6 = 47; // G6
+      cfg.pin_g7 = 21; // G7
+
+      cfg.pin_b0 = -1;
+      cfg.pin_b1 = -1;
+      cfg.pin_b2 = -1;
+      cfg.pin_b3 = 14; // B3
+      cfg.pin_b4 = 38; // B4
+      cfg.pin_b5 = 18; // B5
+      cfg.pin_b6 = 17; // B6
+      cfg.pin_b7 = 10; // B7
       _bus.config(cfg);
     }
     {
@@ -59,8 +64,8 @@ public:
 
 static LGFX gfx;
 
-static void lvgl_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
-{
+static void lvgl_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area,
+                          lv_color_t *color_p) {
   uint32_t w = area->x2 - area->x1 + 1;
   uint32_t h = area->y2 - area->y1 + 1;
   gfx.startWrite();
@@ -70,14 +75,15 @@ static void lvgl_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t 
   lv_disp_flush_ready(drv);
 }
 
-void lvgl_port_init(void)
-{
+void lvgl_port_init(void) {
   lv_init();
   gfx.init();
 
   size_t buf_sz = 1024 * 40; // 1/15 of screen
-  lv_color_t *buf1 = (lv_color_t *)heap_caps_malloc(buf_sz * sizeof(lv_color_t), MALLOC_CAP_SPIRAM);
-  lv_color_t *buf2 = (lv_color_t *)heap_caps_malloc(buf_sz * sizeof(lv_color_t), MALLOC_CAP_SPIRAM);
+  lv_color_t *buf1 = (lv_color_t *)heap_caps_malloc(
+      buf_sz * sizeof(lv_color_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  lv_color_t *buf2 = (lv_color_t *)heap_caps_malloc(
+      buf_sz * sizeof(lv_color_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   assert(buf1 && esp_ptr_external_ram(buf1));
   assert(buf2 && esp_ptr_external_ram(buf2));
   static lv_disp_draw_buf_t draw_buf;


### PR DESCRIPTION
## Summary
- map HSYNC/VSYNC/DE/PCLK and RGB565 pins to the ESP32-S3 Touch LCD 7B wiring
- allocate LVGL draw buffers from PSRAM with 8-bit capability

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c750284bb8832393d7a2abc9cc601e