### PR TITLE
feat(terrarium): sync environment with hosted reptile

### DIFF
--- a/components/game/game.c
+++ b/components/game/game.c
@@ -79,11 +79,11 @@ static void btn_new_game_event(lv_event_t *e)
     game_state.reptile.requires_authorisation = info->requires_authorisation;
     game_state.reptile.requires_certificat = info->requires_certificat;
 
-    /* Initial terrarium environment mirrors reptile requirements */
+    /* Host reptile and mirror environment requirements */
+    terrarium_set_reptile(info);
     game_state.terrarium.temperature = info->temperature;
     game_state.terrarium.humidity = info->humidity;
     game_state.terrarium.uv_index = info->uv_index;
-    terrarium_update_environment(info->temperature, info->humidity, info->uv_index);
 
     /* Initialise economic state */
     economy_init(&game_state.economy, 100.0f, 100.0f);
@@ -106,9 +106,11 @@ static void btn_resume_event(lv_event_t *e)
     }
 
     /* Restore terrarium environment */
-    terrarium_update_environment(game_state.terrarium.temperature,
-                                 game_state.terrarium.humidity,
-                                 game_state.terrarium.uv_index);
+    const reptile_info_t *info = reptiles_find(game_state.reptile.species);
+    terrarium_set_reptile(info);
+    game_state.terrarium.temperature = info->temperature;
+    game_state.terrarium.humidity = info->humidity;
+    game_state.terrarium.uv_index = info->uv_index;
 
     /* Restore terrarium inventory */
     for (size_t i = 0; i < game_state.terrarium.item_count; ++i) {

--- a/components/game/terrarium/terrarium.c
+++ b/components/game/terrarium/terrarium.c
@@ -15,6 +15,8 @@ static struct {
     float uv_index;
 } environment;
 
+static const reptile_info_t *current_reptile;
+
 bool terrarium_add_item(const char *item)
 {
     if (!item || item_count >= MAX_ITEMS) {
@@ -29,8 +31,23 @@ bool terrarium_add_item(const char *item)
 
 void terrarium_update_environment(float temperature, float humidity, float uv_index)
 {
+    if (current_reptile) {
+        temperature = current_reptile->temperature;
+        humidity = current_reptile->humidity;
+        uv_index = current_reptile->uv_index;
+    }
     environment.temperature = temperature;
     environment.humidity = humidity;
     environment.uv_index = uv_index;
     ESP_LOGI(TAG, "Environment updated T=%.1fC H=%.1f%% UV=%.1f", temperature, humidity, uv_index);
+}
+
+void terrarium_set_reptile(const reptile_info_t *reptile)
+{
+    current_reptile = reptile;
+    if (reptile) {
+        terrarium_update_environment(reptile->temperature,
+                                    reptile->humidity,
+                                    reptile->uv_index);
+    }
 }

--- a/components/game/terrarium/terrarium.h
+++ b/components/game/terrarium/terrarium.h
@@ -2,6 +2,7 @@
 #define TERRARIUM_H
 
 #include <stdbool.h>
+#include "reptiles.h"
 
 /**
  * @brief Add an item to the terrarium inventory.
@@ -12,6 +13,17 @@
  * @return true on success, false if the list is full or item is NULL.
  */
 bool terrarium_add_item(const char *item);
+
+/**
+ * @brief Set the reptile currently hosted in the terrarium.
+ *
+ * The provided reptile description is stored for later reference so that
+ * environmental parameters can automatically mirror the animal's needs.
+ *
+ * @param reptile Pointer to the reptile information. NULL clears the current
+ *        association.
+ */
+void terrarium_set_reptile(const reptile_info_t *reptile);
 
 /**
  * @brief Synchronise environment parameters with the hosted reptile.


### PR DESCRIPTION
## Summary
- track reptile assigned to the terrarium and auto-apply its environmental requirements
- initialise and resume games by registering the reptile before loading inventory

## Testing
- `idf.py set-target esp32s3` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7530381888323be7b0173d1533e48