### PR TITLE
feat(terrarium): track environment and expose state

### DIFF
--- a/components/game/terrarium/terrarium.c
+++ b/components/game/terrarium/terrarium.c
@@ -3,28 +3,19 @@
 #include <string.h>
 
 #define TAG "terrarium"
-#define MAX_ITEMS 16
-#define ITEM_NAME_LEN 32
 
-static char items[MAX_ITEMS][ITEM_NAME_LEN];
-static size_t item_count;
-
-static struct {
-    float temperature;
-    float humidity;
-    float uv_index;
-} environment;
+static terrarium_t state;
 
 static const reptile_info_t *current_reptile;
 
 bool terrarium_add_item(const char *item)
 {
-    if (!item || item_count >= MAX_ITEMS) {
+    if (!item || state.item_count >= TERRARIUM_MAX_ITEMS) {
         return false;
     }
-    strncpy(items[item_count], item, ITEM_NAME_LEN - 1);
-    items[item_count][ITEM_NAME_LEN - 1] = '\0';
-    item_count++;
+    strncpy(state.items[state.item_count], item, TERRARIUM_ITEM_NAME_LEN - 1);
+    state.items[state.item_count][TERRARIUM_ITEM_NAME_LEN - 1] = '\0';
+    state.item_count++;
     ESP_LOGI(TAG, "Added item: %s", item);
     return true;
 }
@@ -36,9 +27,9 @@ void terrarium_update_environment(float temperature, float humidity, float uv_in
         humidity = current_reptile->humidity;
         uv_index = current_reptile->uv_index;
     }
-    environment.temperature = temperature;
-    environment.humidity = humidity;
-    environment.uv_index = uv_index;
+    state.temperature = temperature;
+    state.humidity = humidity;
+    state.uv_index = uv_index;
     ESP_LOGI(TAG, "Environment updated T=%.1fC H=%.1f%% UV=%.1f", temperature, humidity, uv_index);
 }
 
@@ -50,4 +41,9 @@ void terrarium_set_reptile(const reptile_info_t *reptile)
                                     reptile->humidity,
                                     reptile->uv_index);
     }
+}
+
+const terrarium_t *terrarium_get_state(void)
+{
+    return &state;
 }

--- a/components/game/terrarium/terrarium.h
+++ b/components/game/terrarium/terrarium.h
@@ -2,7 +2,19 @@
 #define TERRARIUM_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include "reptiles.h"
+
+#define TERRARIUM_MAX_ITEMS 16
+#define TERRARIUM_ITEM_NAME_LEN 32
+
+typedef struct {
+    size_t item_count;
+    char items[TERRARIUM_MAX_ITEMS][TERRARIUM_ITEM_NAME_LEN];
+    float temperature;
+    float humidity;
+    float uv_index;
+} terrarium_t;
 
 /**
  * @brief Add an item to the terrarium inventory.
@@ -36,5 +48,12 @@ void terrarium_set_reptile(const reptile_info_t *reptile);
  * @param uv_index Target UV index.
  */
 void terrarium_update_environment(float temperature, float humidity, float uv_index);
+
+/**
+ * @brief Retrieve current terrarium state snapshot.
+ *
+ * @return Pointer to internal terrarium state structure.
+ */
+const terrarium_t *terrarium_get_state(void);
 
 #endif // TERRARIUM_H


### PR DESCRIPTION
## Summary
- centralize terrarium inventory and environment in a shared state struct
- sync temperature, humidity and UV index with hosted reptile
- expose current terrarium snapshot via getter

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fbb9bd148323840e3d8ff7bc6ea4