### PR TITLE
feat: manage reptile requirements with PSRAM validation

### DIFF
--- a/components/game/reptiles/reptiles.h
+++ b/components/game/reptiles/reptiles.h
@@ -3,13 +3,21 @@
 #include <stddef.h>
 
 typedef struct {
-    const char *species;
     float temperature;
     float humidity;
     float uv_index;
     float terrarium_min_size;
+} reptile_needs_t;
+
+typedef struct {
     bool requires_authorisation;
     bool requires_certificat;
+} reptile_legal_t;
+
+typedef struct {
+    const char *species;
+    reptile_needs_t needs;
+    reptile_legal_t legal;
 } reptile_info_t;
 
 bool reptiles_load(void);
@@ -17,3 +25,5 @@ const reptile_info_t *reptiles_get(size_t *count);
 const reptile_info_t *reptiles_find(const char *species);
 /* Validate biological needs and legal compliance */
 bool reptiles_validate(const reptile_info_t *info);
+/* Add a reptile after validation */
+bool reptiles_add(const reptile_info_t *info);

--- a/components/game/reptiles/reptiles.json
+++ b/components/game/reptiles/reptiles.json
@@ -1,20 +1,28 @@
 [
   {
     "species": "Pogona vitticeps",
-    "temperature": 40.0,
-    "humidity": 30.0,
-    "uv_index": 5.0,
-    "terrarium_min_size": 1.0,
-    "requires_authorisation": false,
-    "requires_certificat": true
+    "needs": {
+      "temperature": 40.0,
+      "humidity": 30.0,
+      "uv_index": 5.0,
+      "terrarium_min_size": 1.0
+    },
+    "legal": {
+      "requires_authorisation": false,
+      "requires_certificat": true
+    }
   },
   {
     "species": "Python regius",
-    "temperature": 32.0,
-    "humidity": 60.0,
-    "uv_index": 3.0,
-    "terrarium_min_size": 0.5,
-    "requires_authorisation": true,
-    "requires_certificat": true
+    "needs": {
+      "temperature": 32.0,
+      "humidity": 60.0,
+      "uv_index": 3.0,
+      "terrarium_min_size": 0.5
+    },
+    "legal": {
+      "requires_authorisation": true,
+      "requires_certificat": true
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- model reptiles with grouped biological needs and legal status
- load reptile data from JSON into PSRAM
- allow adding reptiles after validating requirements

## Testing
- `idf.py build` *(fails: command not found)*
- `gcc -c components/game/reptiles/reptiles.c -o /tmp/reptiles.o` *(fails: esp_heap_caps.h: No such file or directory)*
- `python -m json.tool components/game/reptiles/reptiles.json`

------
https://chatgpt.com/codex/tasks/task_e_68c7fc7a22108323b5d47b2a5b353bc7