### PR TITLE
feat: add budget deficit impact on wellbeing

### DIFF
--- a/components/game/economy.c
+++ b/components/game/economy.c
@@ -13,6 +13,10 @@
 #define WELLBEING_MAX       100.0f
 #define WELLBEING_MIN       0.0f
 
+/* Wellbeing penalty when expenses cannot be covered */
+#define DEFICIT_PENALTY_BASE 5.0f
+#define DEFICIT_PENALTY_RATE 0.1f
+
 /**
  * @brief Apply the weekly income when a new week starts.
  */
@@ -29,30 +33,39 @@ static void economy_apply_weekly_credit(economy_t *eco)
 
 /**
  * @brief Deduct mandatory daily expenses from the player budget.
+ *
+ * @return Amount of credits missing to cover the expenses.
  */
-static void economy_apply_daily_expenses(economy_t *eco)
+static float economy_apply_daily_expenses(economy_t *eco)
 {
     if (!eco) {
-        return;
+        return 0.0f;
     }
 
-    eco->budget -= FOOD_COST_PER_DAY;
-    eco->budget -= ELECTRICITY_COST;
-    eco->budget -= VETERINARY_COST;
-    eco->budget -= EQUIPMENT_COST;
+    const float expenses = FOOD_COST_PER_DAY + ELECTRICITY_COST +
+                           VETERINARY_COST + EQUIPMENT_COST;
+    const float available = eco->budget > 0.0f ? eco->budget : 0.0f;
+
+    eco->budget -= expenses;
+
+    float deficit = expenses - available;
+    return deficit > 0.0f ? deficit : 0.0f;
 }
 
 /**
- * @brief Adjust the reptile wellbeing according to the available budget.
+ * @brief Adjust the reptile wellbeing according to the budget status.
+ *
+ * @param deficit Unpaid portion of today's expenses.
  */
-static void economy_apply_wellbeing(economy_t *eco)
+static void economy_apply_wellbeing(economy_t *eco, float deficit)
 {
     if (!eco) {
         return;
     }
 
-    if (eco->budget < 0.0f) {
-        eco->wellbeing -= 5.0f;
+    if (deficit > 0.0f) {
+        eco->wellbeing -= DEFICIT_PENALTY_BASE +
+                          deficit * DEFICIT_PENALTY_RATE;
     } else if (eco->budget < 50.0f) {
         eco->wellbeing -= 1.0f;
     } else if (eco->budget > 200.0f) {
@@ -86,6 +99,6 @@ void economy_next_day(economy_t *eco)
     eco->day++;
 
     economy_apply_weekly_credit(eco);
-    economy_apply_daily_expenses(eco);
-    economy_apply_wellbeing(eco);
+    float deficit = economy_apply_daily_expenses(eco);
+    economy_apply_wellbeing(eco, deficit);
 }


### PR DESCRIPTION
## Summary
- factor daily expenses to compute unpaid deficits
- degrade reptile wellbeing based on budget shortfall

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fdde4e008323be9f335a780796d7