### PR TITLE
Add mode selection and real terrarium stub

### DIFF
--- a/components/real_terrarium/CMakeLists.txt
+++ b/components/real_terrarium/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "real_terrarium.c" INCLUDE_DIRS ".")

--- a/components/real_terrarium/real_terrarium.c
+++ b/components/real_terrarium/real_terrarium.c
@@ -1,0 +1,18 @@
+#include "real_terrarium.h"
+#include "esp_log.h"
+
+static const char *TAG = "real_terrarium";
+
+void real_terrarium_init(void)
+{
+    ESP_LOGI(TAG, "Initializing real terrarium module");
+}
+
+void real_terrarium_show_main_screen(void)
+{
+    lv_obj_t *scr = lv_obj_create(NULL);
+    lv_obj_t *label = lv_label_create(scr);
+    lv_label_set_text(label, "Gestion Terrariums Réels");
+    lv_obj_center(label);
+    lv_scr_load(scr);
+}

--- a/components/real_terrarium/real_terrarium.h
+++ b/components/real_terrarium/real_terrarium.h
@@ -1,0 +1,12 @@
+#ifndef REAL_TERRARIUM_H
+#define REAL_TERRARIUM_H
+
+#include "lvgl.h"
+
+/* Initialize real terrarium management module */
+void real_terrarium_init(void);
+
+/* Display main screen for real terrarium management */
+void real_terrarium_show_main_screen(void);
+
+#endif // REAL_TERRARIUM_H

--- a/main/main.c
+++ b/main/main.c
@@ -3,6 +3,7 @@
 #include "touch_gt911.h"
 #include "storage.h"
 #include "game.h"
+#include "real_terrarium.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -25,6 +26,40 @@ static void gui_task(void *arg)
     }
 }
 
+static void sim_btn_event_handler(lv_event_t *e)
+{
+    (void)e;
+    game_show_main_menu();
+}
+
+static void real_btn_event_handler(lv_event_t *e)
+{
+    (void)e;
+    real_terrarium_init();
+    real_terrarium_show_main_screen();
+}
+
+void show_mode_selector(void)
+{
+    lv_obj_t *scr = lv_obj_create(NULL);
+
+    lv_obj_t *btn_sim = lv_btn_create(scr);
+    lv_obj_align(btn_sim, LV_ALIGN_CENTER, 0, -40);
+    lv_obj_t *label_sim = lv_label_create(btn_sim);
+    lv_label_set_text(label_sim, "Simulation");
+    lv_obj_center(label_sim);
+    lv_obj_add_event_cb(btn_sim, sim_btn_event_handler, LV_EVENT_CLICKED, NULL);
+
+    lv_obj_t *btn_real = lv_btn_create(scr);
+    lv_obj_align(btn_real, LV_ALIGN_CENTER, 0, 40);
+    lv_obj_t *label_real = lv_label_create(btn_real);
+    lv_label_set_text(label_real, "Réel");
+    lv_obj_center(label_real);
+    lv_obj_add_event_cb(btn_real, real_btn_event_handler, LV_EVENT_CLICKED, NULL);
+
+    lv_scr_load(scr);
+}
+
 void app_main(void)
 {
     ESP_LOGI(TAG, "Initializing system");
@@ -43,5 +78,5 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_timer_create(&tick_args, &tick_timer));
     ESP_ERROR_CHECK(esp_timer_start_periodic(tick_timer, 1000));
 
-    game_show_main_menu();
+    show_mode_selector();
 }


### PR DESCRIPTION
## Summary
- Add LVGL mode selector with Simulation and Réel buttons
- Stub out real terrarium module and integrate into build
- Call mode selector after driver init

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c817ead36483239d8796fb1ea10d60