### PR TITLE
feat: simulate reptile growth and health

### DIFF
--- a/components/game/reptiles/reptiles.h
+++ b/components/game/reptiles/reptiles.h
@@ -2,6 +2,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+/* Growth and health thresholds */
+#define REPTILE_GROWTH_MATURE 1.0f       /*!< Growth value at maturity          */
+#define REPTILE_HEALTH_SICK_RATIO 0.3f   /*!< Fraction of max health for illness*/
+#define REPTILE_HEALTH_DEAD 0.0f         /*!< Health level indicating death     */
+
 /* CITES appendix classification */
 typedef enum {
     REPTILE_CITES_NONE = 0, /*!< Species not listed in CITES */


### PR DESCRIPTION
## Summary
- add periodic timer to update reptile growth and health
- trigger maturity, care and death events with thresholds
- persist reptile status fields through save/load

## Testing
- ⚠️ `idf.py build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c824affa7083238841c538b3f35a16