### PR TITLE
Refine game component registration formatting

### DIFF
--- a/components/game/CMakeLists.txt
+++ b/components/game/CMakeLists.txt
@@ -1,6 +1,8 @@
-idf_component_register(SRCS "game.c" "room.c" "economy.c" "environment.c" \
-                        "terrarium/terrarium.c" "reptiles/reptiles.c" \
-                        "terrarium_ui/ui.c" "render3d/render3d.cpp"
-                        INCLUDE_DIRS "." "terrarium" "reptiles" "terrarium_ui" "render3d"
-                        REQUIRES lvgl storage lovyangfx cJSON assets
-                        EMBED_TXTFILES "reptiles/reptiles.json")
+idf_component_register(
+    SRCS "game.c" "room.c" "economy.c" "environment.c"
+         "terrarium/terrarium.c" "reptiles/reptiles.c"
+         "terrarium_ui/ui.c" "render3d/render3d.cpp"
+    INCLUDE_DIRS "." "terrarium" "reptiles" "terrarium_ui" "render3d"
+    REQUIRES lvgl storage lovyangfx cJSON assets
+    EMBED_TXTFILES "reptiles/reptiles.json"
+)


### PR DESCRIPTION
## Summary
- reformat the game component CMake registration to remove line continuations
- adopt standard idf_component_register layout for readability

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8437c53448323b3fe1bd68cdc74f1