### PR TITLE
Fix real_mode component registration formatting

### DIFF
--- a/components/real_mode/CMakeLists.txt
+++ b/components/real_mode/CMakeLists.txt
@@ -1,3 +1,5 @@
-idf_component_register(SRCS "real_mode.c" "sensors.c" "actuators.c" "dashboard.c" "logging.c" \
-                    INCLUDE_DIRS "." \
-                    REQUIRES storage)
+idf_component_register(
+    SRCS "real_mode.c" "sensors.c" "actuators.c" "dashboard.c" "logging.c"
+    INCLUDE_DIRS "."
+    REQUIRES storage
+)


### PR DESCRIPTION
## Summary
- reformat real_mode component CMake declaration using canonical multiline idf_component_register syntax
- ensure closing parenthesis is separated from arguments so CMake parses correctly

## Testing
- `idf.py reconfigure` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8628571248323b37bb476d1377969