### PR TITLE
Fix cJSON dependency name

### DIFF
--- a/components/game/CMakeLists.txt
+++ b/components/game/CMakeLists.txt
@@ -3,6 +3,6 @@ idf_component_register(
          "terrarium/terrarium.c" "reptiles/reptiles.c"
          "terrarium_ui/ui.c" "render3d/render3d.cpp"
     INCLUDE_DIRS "." "terrarium" "reptiles" "terrarium_ui" "render3d"
-    REQUIRES lvgl storage lovyangfx cJSON assets
+    REQUIRES lvgl storage lovyangfx cjson assets
     EMBED_TXTFILES "reptiles/reptiles.json"
 )


### PR DESCRIPTION
## Summary
- reference ESP-IDF's bundled cjson component in the game module CMake list to resolve dependency lookup failures

## Testing
- command not run (idf.py reconfigure unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8638f006883239b5b08f49efc2595