### PR TITLE
Handle generated asset binaries during configure

### DIFF
--- a/components/assets/CMakeLists.txt
+++ b/components/assets/CMakeLists.txt
@@ -17,6 +17,17 @@ foreach(png ${ASSET_PNG})
     list(APPEND ASSET_BIN_REL ${rel})
 endforeach()
 
+if(ASSET_BIN)
+    # Mark generated assets so that CMake does not require them to exist at
+    # configure time. The actual conversion is handled by the custom command
+    # below.
+    set_source_files_properties(${ASSET_BIN} PROPERTIES GENERATED TRUE)
+endif()
+
+if(ASSET_BIN_REL)
+    set_source_files_properties(${ASSET_BIN_REL} PROPERTIES GENERATED TRUE)
+endif()
+
 set(EMBED_ARGS)
 if(ASSET_BIN_REL)
     set(EMBED_ARGS EMBED_FILES ${ASSET_BIN_REL})


### PR DESCRIPTION
## Summary
- mark generated LVGL asset binaries as generated so CMake accepts them before conversion
- apply the same generated flag to the relative paths used for embedding to keep ESP-IDF happy

## Testing
- not run (ESP-IDF toolchain not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c8682516288323abe505de307e4632