### PR TITLE
Fix asset embed path relative to component

### DIFF
--- a/components/assets/CMakeLists.txt
+++ b/components/assets/CMakeLists.txt
@@ -13,7 +13,7 @@ foreach(png ${ASSET_PNG})
     get_filename_component(dir ${png} DIRECTORY)
     set(bin ${dir}/${name}.bin)
     list(APPEND ASSET_BIN ${bin})
-    file(RELATIVE_PATH rel ${CMAKE_SOURCE_DIR} ${bin})
+    file(RELATIVE_PATH rel ${CMAKE_CURRENT_SOURCE_DIR} ${bin})
     list(APPEND ASSET_BIN_REL ${rel})
 endforeach()
 


### PR DESCRIPTION
## Summary
- compute generated asset paths relative to the assets component so ESP-IDF embeds binaries from the correct location

## Testing
- ./assets/generate_assets.sh


------
https://chatgpt.com/codex/tasks/task_e_68c86c969dfc8323aeae74322a2d1de6