### PR TITLE
Fix FAT info query with 64-bit counters

### DIFF
--- a/components/storage/logs.c
+++ b/components/storage/logs.c
@@ -14,7 +14,7 @@
 #define TAG "storage_log"
 #define LOG_BASE_PATH "/sdcard/logs"
 #define LOG_MOUNT_POINT "/sdcard"
-#define LOG_MIN_FREE_BYTES (1024 * 1024) /* 1 MB */
+#define LOG_MIN_FREE_BYTES (1024ULL * 1024ULL) /* 1 MB */
 
 static bool ensure_path(void)
 {
@@ -52,15 +52,15 @@ static void rotate_log(const char *path)
 
 static bool check_space(const char *path)
 {
-    size_t total_bytes = 0;
-    size_t free_bytes = 0;
+    uint64_t total_bytes = 0;
+    uint64_t free_bytes = 0;
     esp_err_t err = esp_vfs_fat_info(LOG_MOUNT_POINT, &total_bytes, &free_bytes);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "Failed to query free space: %s", esp_err_to_name(err));
         return true; /* Do not block logging if information is unavailable */
     }
     if (free_bytes < LOG_MIN_FREE_BYTES) {
-        ESP_LOGW(TAG, "Low free space (%zu bytes), rotating log", free_bytes);
+        ESP_LOGW(TAG, "Low free space (%" PRIu64 " bytes), rotating log", free_bytes);
         rotate_log(path);
     }
     return true;


### PR DESCRIPTION
## Summary
- update the log storage free-space check to use 64-bit counters compatible with esp_vfs_fat_info
- log the available space with PRIu64 formatting and make the free-space threshold 64-bit safe

## Testing
- `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c86fcee47883239cc9ae585b4fd6d2