### PR TITLE
Add compatibility shim for removed gpio_hal_iomux_func_sel

### DIFF
--- a/project_include.cmake
+++ b/project_include.cmake
@@ -1,0 +1,4 @@
+set(ESP_IDF_COMPAT_HEADER "${CMAKE_CURRENT_LIST_DIR}/tools/esp_idf_compat/gpio_hal_compat.h")
+if(EXISTS "${ESP_IDF_COMPAT_HEADER}")
+    idf_build_set_property(COMPILE_OPTIONS "-include" "${ESP_IDF_COMPAT_HEADER}" APPEND)
+endif()

--- a/tools/esp_idf_compat/gpio_hal_compat.h
+++ b/tools/esp_idf_compat/gpio_hal_compat.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "hal/gpio_hal.h"
+
+#ifndef gpio_hal_iomux_func_sel
+#include "soc/io_mux_reg.h"
+#include "soc/soc.h"
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
+#include "soc/usb_serial_jtag_reg.h"
+#endif
+
+static inline void gpio_hal_iomux_func_sel(uint32_t pin_name, uint32_t func)
+{
+#if defined(USB_SERIAL_JTAG_CONF0_REG) && defined(IO_MUX_GPIO19_REG) && defined(IO_MUX_GPIO20_REG)
+    if (pin_name == IO_MUX_GPIO19_REG || pin_name == IO_MUX_GPIO20_REG) {
+        CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
+    }
+#endif
+    PIN_FUNC_SELECT(pin_name, func);
+}
+#endif // gpio_hal_iomux_func_sel


### PR DESCRIPTION
## Summary
- add a project-wide compatibility header that reintroduces gpio_hal_iomux_func_sel when it is missing
- force-include the compatibility header for every compilation unit to keep LovyanGFX building on ESP-IDF 5.5

## Testing
- not run (ESP-IDF toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8727e1c2883239af8da4ea083c1a1