### PR TITLE
Fix LovyanGFX build by forcing gpio HAL compat header inclusion

### DIFF
--- a/project_include.cmake
+++ b/project_include.cmake
@@ -1,4 +1,5 @@
 set(ESP_IDF_COMPAT_HEADER "${CMAKE_CURRENT_LIST_DIR}/tools/esp_idf_compat/gpio_hal_compat.h")
 if(EXISTS "${ESP_IDF_COMPAT_HEADER}")
-    idf_build_set_property(COMPILE_OPTIONS "-include" "${ESP_IDF_COMPAT_HEADER}" APPEND)
+    cmake_path(CONVERT "${ESP_IDF_COMPAT_HEADER}" TO_CMAKE_PATH_LIST ESP_IDF_COMPAT_HEADER_CMAKE_STYLE)
+    add_compile_options(-include "${ESP_IDF_COMPAT_HEADER_CMAKE_STYLE}")
 endif()


### PR DESCRIPTION
## Summary
- ensure the ESP-IDF gpio HAL compatibility shim is force-included for every translation unit
- normalise the compatibility header path before injecting it into the global compile options

## Testing
- not run (ESP-IDF toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c874d51fd483239a8051639551d153