### PR TITLE
Fix gpio HAL compatibility for ESP-IDF v5.5

### DIFF
--- a/tools/esp_idf_compat/gpio_hal_compat.h
+++ b/tools/esp_idf_compat/gpio_hal_compat.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "hal/gpio_hal.h"
+#include "esp_idf_version.h"
 
 #ifndef gpio_hal_iomux_func_sel
 #include "soc/io_mux_reg.h"
@@ -21,3 +22,21 @@ static inline void gpio_hal_iomux_func_sel(uint32_t pin_name, uint32_t func)
     PIN_FUNC_SELECT(pin_name, func);
 }
 #endif // gpio_hal_iomux_func_sel
+
+#if defined(gpio_hal_func_sel)
+#ifndef ESP_IDF_GPIO_HAL_FUNC_SEL_COMPAT
+#define ESP_IDF_GPIO_HAL_FUNC_SEL_COMPAT
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+#undef gpio_hal_func_sel
+
+#define ESP_IDF_GPIO_HAL_FUNC_SEL_GET_MACRO(_1, _2, _3, NAME, ...) NAME
+#define ESP_IDF_GPIO_HAL_FUNC_SEL_2ARGS(pin_name, func) gpio_hal_iomux_func_sel((uint32_t)(pin_name), (func))
+#define ESP_IDF_GPIO_HAL_FUNC_SEL_3ARGS(hal, gpio_num, func) gpio_ll_func_sel((hal)->dev, (gpio_num), (func))
+
+#define gpio_hal_func_sel(...) \
+    ESP_IDF_GPIO_HAL_FUNC_SEL_GET_MACRO(__VA_ARGS__, \
+                                        ESP_IDF_GPIO_HAL_FUNC_SEL_3ARGS, \
+                                        ESP_IDF_GPIO_HAL_FUNC_SEL_2ARGS)(__VA_ARGS__)
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+#endif // ESP_IDF_GPIO_HAL_FUNC_SEL_COMPAT
+#endif // defined(gpio_hal_func_sel)


### PR DESCRIPTION
## Summary
- extend the GPIO HAL compatibility shim to handle the new three-argument gpio_hal_func_sel macro introduced in ESP-IDF v5.5 while keeping backward compatibility with LovyanGFX's legacy two-argument usage

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c87b7d660c83238fbafddb84bc5fef