### PR TITLE
Add terrarium reset helper

### DIFF
--- a/components/game/game.c
+++ b/components/game/game.c
@@ -115,8 +115,7 @@ bool game_select_terrarium(size_t index) {
     return false;
   current_slot = index;
   terrarium_slot_t *slot = &game_state.terrariums[index];
-  const terrarium_t *cur = terrarium_get_state();
-  memset((void *)cur, 0, sizeof(*cur));
+  terrarium_reset();
   const reptile_info_t *info = reptiles_find(slot->reptile.species);
   if (info)
     terrarium_set_reptile(info);

--- a/components/game/terrarium/terrarium.c
+++ b/components/game/terrarium/terrarium.c
@@ -8,6 +8,12 @@ static terrarium_t state;
 
 static const reptile_info_t *current_reptile;
 
+void terrarium_reset(void)
+{
+    memset(&state, 0, sizeof(state));
+    current_reptile = NULL;
+}
+
 bool terrarium_add_item(const char *item)
 {
     if (!item || state.item_count >= TERRARIUM_MAX_ITEMS) {

--- a/components/game/terrarium/terrarium.h
+++ b/components/game/terrarium/terrarium.h
@@ -22,6 +22,11 @@ typedef struct {
 } terrarium_t;
 
 /**
+ * @brief Reset the terrarium state to its default values.
+ */
+void terrarium_reset(void);
+
+/**
  * @brief Add an item to the terrarium inventory.
  *
  * Stores the item name in an internal list for later reference.


### PR DESCRIPTION
## Summary
- add a dedicated terrarium_reset helper that clears the cached terrarium state
- reuse the helper in the game selection flow instead of a local memset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c920603a088323bc5e78c820df605e