### PR TITLE
Add new game controls with persistent save slots

### DIFF
--- a/components/reptile_logic/reptile_logic.h
+++ b/components/reptile_logic/reptile_logic.h
@@ -34,10 +34,13 @@ typedef enum {
   REPTILE_HUMEUR_THRESHOLD = 40,
 } reptile_threshold_t;
 
+enum { REPTILE_SLOT_NAME_MAX = 64 };
+
 esp_err_t reptile_init(reptile_t *r, bool simulation);
 void reptile_update(reptile_t *r, uint32_t elapsed_ms);
 esp_err_t reptile_load(reptile_t *r);
 esp_err_t reptile_save(reptile_t *r);
+esp_err_t reptile_select_save(const char *slot_name, bool simulation);
 void reptile_feed(reptile_t *r);
 void reptile_give_water(reptile_t *r);
 void reptile_heat(reptile_t *r);

--- a/main/main.c
+++ b/main/main.c
@@ -91,6 +91,22 @@ static void menu_btn_game_cb(lv_event_t *e) {
   start_game_mode();
 }
 
+static void menu_btn_new_game_cb(lv_event_t *e) {
+  (void)e;
+  reptile_game_prepare_new_game();
+  game_mode_set(GAME_MODE_SIMULATION);
+  save_last_mode(APP_MODE_GAME);
+  start_game_mode();
+}
+
+static void menu_btn_resume_cb(lv_event_t *e) {
+  (void)e;
+  reptile_game_prepare_resume();
+  game_mode_set(GAME_MODE_SIMULATION);
+  save_last_mode(APP_MODE_GAME);
+  start_game_mode();
+}
+
 static void menu_btn_real_cb(lv_event_t *e) {
   (void)e;
   game_mode_set(GAME_MODE_REAL);
@@ -347,15 +363,31 @@ void app_main() {
 
     lv_obj_t *btn_game = lv_btn_create(menu_screen);
     lv_obj_set_size(btn_game, 200, 50);
-    lv_obj_align(btn_game, LV_ALIGN_CENTER, 0, -60);
+    lv_obj_align(btn_game, LV_ALIGN_CENTER, 0, -140);
     lv_obj_add_event_cb(btn_game, menu_btn_game_cb, LV_EVENT_CLICKED, NULL);
     lv_obj_t *label = lv_label_create(btn_game);
     lv_label_set_text(label, "Mode Jeu");
     lv_obj_center(label);
 
+    lv_obj_t *btn_new = lv_btn_create(menu_screen);
+    lv_obj_set_size(btn_new, 200, 50);
+    lv_obj_align(btn_new, LV_ALIGN_CENTER, 0, -70);
+    lv_obj_add_event_cb(btn_new, menu_btn_new_game_cb, LV_EVENT_CLICKED, NULL);
+    label = lv_label_create(btn_new);
+    lv_label_set_text(label, "Nouvelle partie");
+    lv_obj_center(label);
+
+    lv_obj_t *btn_resume = lv_btn_create(menu_screen);
+    lv_obj_set_size(btn_resume, 200, 50);
+    lv_obj_align(btn_resume, LV_ALIGN_CENTER, 0, 0);
+    lv_obj_add_event_cb(btn_resume, menu_btn_resume_cb, LV_EVENT_CLICKED, NULL);
+    label = lv_label_create(btn_resume);
+    lv_label_set_text(label, "Reprendre");
+    lv_obj_center(label);
+
     lv_obj_t *btn_real = lv_btn_create(menu_screen);
     lv_obj_set_size(btn_real, 200, 50);
-    lv_obj_align(btn_real, LV_ALIGN_CENTER, 0, 0);
+    lv_obj_align(btn_real, LV_ALIGN_CENTER, 0, 70);
     lv_obj_add_event_cb(btn_real, menu_btn_real_cb, LV_EVENT_CLICKED, NULL);
     label = lv_label_create(btn_real);
     lv_label_set_text(label, "Mode R\u00e9el");
@@ -363,7 +395,7 @@ void app_main() {
 
     lv_obj_t *btn_settings = lv_btn_create(menu_screen);
     lv_obj_set_size(btn_settings, 200, 50);
-    lv_obj_align(btn_settings, LV_ALIGN_CENTER, 0, 60);
+    lv_obj_align(btn_settings, LV_ALIGN_CENTER, 0, 140);
     lv_obj_add_event_cb(btn_settings, menu_btn_settings_cb, LV_EVENT_CLICKED,
                         NULL);
     label = lv_label_create(btn_settings);

--- a/main/reptile_game.h
+++ b/main/reptile_game.h
@@ -19,6 +19,8 @@ bool reptile_game_is_active(void);
 
 void reptile_game_start(esp_lcd_panel_handle_t panel,
                         esp_lcd_touch_handle_t touch);
+void reptile_game_prepare_new_game(void);
+void reptile_game_prepare_resume(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add explicit "Nouvelle partie" and "Reprendre" actions to the LVGL menu
- reset the reptile state or resume from disk according to the selected action and generate new save slots when required
- persist the active save slot on the SD card so multiple simulation saves can coexist

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94fe4dee0832390f462f7e9782669