### PR TITLE
Add I2C light/UV sensors and real-time dashboard controls

### DIFF
--- a/components/gpio/gpio.c
+++ b/components/gpio/gpio.c
@@ -80,6 +80,57 @@ void reptile_heat_gpio(void)
     }
 }
 
+void reptile_fan_set(bool on)
+{
+    gpio_select_driver();
+    if (s_driver && s_driver->set_fan) {
+        s_driver->set_fan(on);
+    }
+}
+
+bool reptile_fan_get(void)
+{
+    gpio_select_driver();
+    if (s_driver && s_driver->get_fan) {
+        return s_driver->get_fan();
+    }
+    return false;
+}
+
+void reptile_uv_lamp_set(bool on)
+{
+    gpio_select_driver();
+    if (s_driver && s_driver->set_uv_lamp) {
+        s_driver->set_uv_lamp(on);
+    }
+}
+
+bool reptile_uv_lamp_get(void)
+{
+    gpio_select_driver();
+    if (s_driver && s_driver->get_uv_lamp) {
+        return s_driver->get_uv_lamp();
+    }
+    return false;
+}
+
+void reptile_light_set(bool on)
+{
+    gpio_select_driver();
+    if (s_driver && s_driver->set_light) {
+        s_driver->set_light(on);
+    }
+}
+
+bool reptile_light_get(void)
+{
+    gpio_select_driver();
+    if (s_driver && s_driver->get_light) {
+        return s_driver->get_light();
+    }
+    return false;
+}
+
 void reptile_actuators_deinit(void)
 {
     if (s_driver && s_driver->deinit) {

--- a/components/gpio/gpio.h
+++ b/components/gpio/gpio.h
@@ -16,12 +16,16 @@
 
 #include "driver/gpio.h"  // ESP-IDF GPIO driver library
 #include "esp_err.h"
+#include <stdbool.h>
 
 /* Pin Definitions */
-#define LED_GPIO_PIN     GPIO_NUM_6  /* GPIO pin connected to the LED */
-#define SERVO_FEED_PIN   GPIO_NUM_17 /* Servo control pin for feeding */
-#define WATER_PUMP_PIN   GPIO_NUM_18 /* Pump control pin for watering */
-#define HEAT_RES_PIN     GPIO_NUM_19 /* Heating resistor control pin */
+#define LED_GPIO_PIN     GPIO_NUM_6   /* GPIO pin connected to the LED */
+#define SERVO_FEED_PIN   GPIO_NUM_17  /* Servo control pin for feeding */
+#define WATER_PUMP_PIN   GPIO_NUM_18  /* Pump control pin for watering */
+#define HEAT_RES_PIN     GPIO_NUM_19  /* Heating resistor control pin */
+#define FAN_PIN          GPIO_NUM_33  /* Ventilation fan */
+#define UV_LAMP_PIN      GPIO_NUM_34  /* UV lighting */
+#define LIGHT_PIN        GPIO_NUM_35  /* Visible lighting */
 
 /* Function Prototypes */
 
@@ -34,6 +38,12 @@ typedef struct {
     void (*feed)(void);
     void (*water)(void);
     void (*heat)(void);
+    void (*set_fan)(bool on);
+    bool (*get_fan)(void);
+    void (*set_uv_lamp)(bool on);
+    bool (*get_uv_lamp)(void);
+    void (*set_light)(bool on);
+    bool (*get_light)(void);
     void (*deinit)(void);
 } actuator_driver_t;
 
@@ -44,6 +54,12 @@ uint8_t DEV_Digital_Read(uint16_t Pin);
 void reptile_feed_gpio(void);
 void reptile_water_gpio(void);
 void reptile_heat_gpio(void);
+void reptile_fan_set(bool on);
+bool reptile_fan_get(void);
+void reptile_uv_lamp_set(bool on);
+bool reptile_uv_lamp_get(void);
+void reptile_light_set(bool on);
+bool reptile_light_get(void);
 esp_err_t reptile_actuators_init(void);
 void reptile_actuators_deinit(void);
 

--- a/components/gpio/gpio_real.c
+++ b/components/gpio/gpio_real.c
@@ -2,6 +2,10 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+static bool s_fan_state = false;
+static bool s_uv_lamp_state = false;
+static bool s_light_state = false;
+
 static void gpio_real_mode(uint16_t Pin, uint16_t Mode)
 {
     gpio_config_t io_conf = {};
@@ -73,14 +77,56 @@ static void gpio_real_heat(void)
     gpio_set_level(HEAT_RES_PIN, 0);
 }
 
+static void gpio_real_set_fan(bool on)
+{
+    gpio_real_write(FAN_PIN, on ? 1 : 0);
+    s_fan_state = on;
+}
+
+static bool gpio_real_get_fan(void)
+{
+    return s_fan_state;
+}
+
+static void gpio_real_set_uv_lamp(bool on)
+{
+    gpio_real_write(UV_LAMP_PIN, on ? 1 : 0);
+    s_uv_lamp_state = on;
+}
+
+static bool gpio_real_get_uv_lamp(void)
+{
+    return s_uv_lamp_state;
+}
+
+static void gpio_real_set_light(bool on)
+{
+    gpio_real_write(LIGHT_PIN, on ? 1 : 0);
+    s_light_state = on;
+}
+
+static bool gpio_real_get_light(void)
+{
+    return s_light_state;
+}
+
 static esp_err_t gpio_real_init(void)
 {
     gpio_real_mode(SERVO_FEED_PIN, GPIO_MODE_OUTPUT);
     gpio_real_mode(WATER_PUMP_PIN, GPIO_MODE_OUTPUT);
     gpio_real_mode(HEAT_RES_PIN, GPIO_MODE_OUTPUT);
+    gpio_real_mode(FAN_PIN, GPIO_MODE_OUTPUT);
+    gpio_real_mode(UV_LAMP_PIN, GPIO_MODE_OUTPUT);
+    gpio_real_mode(LIGHT_PIN, GPIO_MODE_OUTPUT);
     gpio_real_write(SERVO_FEED_PIN, 0);
     gpio_real_write(WATER_PUMP_PIN, 0);
     gpio_real_write(HEAT_RES_PIN, 0);
+    gpio_real_write(FAN_PIN, 0);
+    gpio_real_write(UV_LAMP_PIN, 0);
+    gpio_real_write(LIGHT_PIN, 0);
+    s_fan_state = false;
+    s_uv_lamp_state = false;
+    s_light_state = false;
     return ESP_OK;
 }
 
@@ -89,10 +135,20 @@ static void gpio_real_deinit(void)
     gpio_real_write(WATER_PUMP_PIN, 0);
     gpio_real_write(HEAT_RES_PIN, 0);
     gpio_real_write(SERVO_FEED_PIN, 0);
+    gpio_real_write(FAN_PIN, 0);
+    gpio_real_write(UV_LAMP_PIN, 0);
+    gpio_real_write(LIGHT_PIN, 0);
+
+    s_fan_state = false;
+    s_uv_lamp_state = false;
+    s_light_state = false;
 
     gpio_real_mode(WATER_PUMP_PIN, GPIO_MODE_INPUT);
     gpio_real_mode(HEAT_RES_PIN, GPIO_MODE_INPUT);
     gpio_real_mode(SERVO_FEED_PIN, GPIO_MODE_INPUT);
+    gpio_real_mode(FAN_PIN, GPIO_MODE_INPUT);
+    gpio_real_mode(UV_LAMP_PIN, GPIO_MODE_INPUT);
+    gpio_real_mode(LIGHT_PIN, GPIO_MODE_INPUT);
 }
 
 const actuator_driver_t gpio_real_driver = {
@@ -104,6 +160,12 @@ const actuator_driver_t gpio_real_driver = {
     .feed = gpio_real_feed,
     .water = gpio_real_water,
     .heat = gpio_real_heat,
+    .set_fan = gpio_real_set_fan,
+    .get_fan = gpio_real_get_fan,
+    .set_uv_lamp = gpio_real_set_uv_lamp,
+    .get_uv_lamp = gpio_real_get_uv_lamp,
+    .set_light = gpio_real_set_light,
+    .get_light = gpio_real_get_light,
     .deinit = gpio_real_deinit,
 };
 

--- a/components/gpio/gpio_sim.c
+++ b/components/gpio/gpio_sim.c
@@ -7,6 +7,9 @@ static const char *TAG = "gpio_sim";
 static uint8_t s_levels[256];
 static bool s_heater_state;
 static bool s_pump_state;
+static bool s_fan_state;
+static bool s_uv_lamp_state;
+static bool s_light_state;
 
 static void gpio_sim_mode(uint16_t Pin, uint16_t Mode)
 {
@@ -29,6 +32,15 @@ static void gpio_sim_write(uint16_t Pin, uint8_t Value)
     if (Pin == WATER_PUMP_PIN) {
         s_pump_state = Value;
     }
+    if (Pin == FAN_PIN) {
+        s_fan_state = Value;
+    }
+    if (Pin == UV_LAMP_PIN) {
+        s_uv_lamp_state = Value;
+    }
+    if (Pin == LIGHT_PIN) {
+        s_light_state = Value;
+    }
 }
 
 static uint8_t gpio_sim_read(uint16_t Pin)
@@ -44,6 +56,39 @@ bool gpio_sim_get_heater_state(void)
 bool gpio_sim_get_pump_state(void)
 {
     return s_pump_state;
+}
+
+static void gpio_sim_set_fan(bool on)
+{
+    s_fan_state = on;
+    ESP_LOGI(TAG, "Simulated fan %s", on ? "ON" : "OFF");
+}
+
+static bool gpio_sim_get_fan(void)
+{
+    return s_fan_state;
+}
+
+static void gpio_sim_set_uv_lamp(bool on)
+{
+    s_uv_lamp_state = on;
+    ESP_LOGI(TAG, "Simulated UV lamp %s", on ? "ON" : "OFF");
+}
+
+static bool gpio_sim_get_uv_lamp(void)
+{
+    return s_uv_lamp_state;
+}
+
+static void gpio_sim_set_light(bool on)
+{
+    s_light_state = on;
+    ESP_LOGI(TAG, "Simulated lighting %s", on ? "ON" : "OFF");
+}
+
+static bool gpio_sim_get_light(void)
+{
+    return s_light_state;
 }
 
 static void gpio_sim_feed(void)
@@ -66,6 +111,9 @@ static void gpio_sim_deinit(void)
     memset(s_levels, 0, sizeof(s_levels));
     s_heater_state = false;
     s_pump_state = false;
+    s_fan_state = false;
+    s_uv_lamp_state = false;
+    s_light_state = false;
 }
 
 static esp_err_t gpio_sim_init(void)
@@ -73,6 +121,9 @@ static esp_err_t gpio_sim_init(void)
     memset(s_levels, 0, sizeof(s_levels));
     s_heater_state = false;
     s_pump_state = false;
+    s_fan_state = false;
+    s_uv_lamp_state = false;
+    s_light_state = false;
     return ESP_OK;
 }
 
@@ -85,6 +136,12 @@ const actuator_driver_t gpio_sim_driver = {
     .feed = gpio_sim_feed,
     .water = gpio_sim_water,
     .heat = gpio_sim_heat,
+    .set_fan = gpio_sim_set_fan,
+    .get_fan = gpio_sim_get_fan,
+    .set_uv_lamp = gpio_sim_set_uv_lamp,
+    .get_uv_lamp = gpio_sim_get_uv_lamp,
+    .set_light = gpio_sim_set_light,
+    .get_light = gpio_sim_get_light,
     .deinit = gpio_sim_deinit,
 };
 

--- a/components/sensors/sensors.c
+++ b/components/sensors/sensors.c
@@ -1,5 +1,6 @@
 #include "sensors.h"
 #include "game_mode.h"
+#include <math.h>
 
 extern const sensor_driver_t sensors_real_driver;
 extern const sensor_driver_t sensors_sim_driver;
@@ -39,6 +40,29 @@ float sensors_read_humidity(void)
         return s_driver->read_humidity();
     }
     return 0.0f;
+}
+
+float sensors_read_lux(void)
+{
+    sensors_select_driver();
+    if (s_driver && s_driver->read_lux) {
+        return s_driver->read_lux();
+    }
+    return NAN;
+}
+
+sensor_uv_data_t sensors_read_uv(void)
+{
+    sensors_select_driver();
+    if (s_driver && s_driver->read_uv) {
+        return s_driver->read_uv();
+    }
+    sensor_uv_data_t data = {
+        .uva = NAN,
+        .uvb = NAN,
+        .uv_index = NAN,
+    };
+    return data;
 }
 
 void sensors_deinit(void)

--- a/components/sensors/sensors.h
+++ b/components/sensors/sensors.h
@@ -8,15 +8,25 @@ extern "C" {
 #endif
 
 typedef struct {
+    float uva;
+    float uvb;
+    float uv_index;
+} sensor_uv_data_t;
+
+typedef struct {
     esp_err_t (*init)(void);
     float (*read_temperature)(void);
     float (*read_humidity)(void);
+    float (*read_lux)(void);
+    sensor_uv_data_t (*read_uv)(void);
     void (*deinit)(void);
 } sensor_driver_t;
 
 esp_err_t sensors_init(void);
 float sensors_read_temperature(void);
 float sensors_read_humidity(void);
+float sensors_read_lux(void);
+sensor_uv_data_t sensors_read_uv(void);
 void sensors_deinit(void);
 
 

--- a/components/sensors/sensors_real.c
+++ b/components/sensors/sensors_real.c
@@ -8,10 +8,123 @@
 
 #define SHT31_ADDR 0x44
 #define TMP117_ADDR 0x48
+#define BH1750_ADDR_LOW 0x23
+#define BH1750_ADDR_HIGH 0x5C
+#define VEML6075_ADDR 0x10
+
+#define BH1750_CMD_POWER_ON 0x01
+#define BH1750_CMD_RESET 0x07
+#define BH1750_CMD_ONE_TIME_HIGH_RES 0x20
+
+#define VEML6075_DEFAULT_CONF 0x18U
+#define VEML6075_REG_CONF 0x00
+#define VEML6075_REG_UVA 0x07
+#define VEML6075_REG_UVB 0x09
+#define VEML6075_REG_UVCOMP1 0x0A
+#define VEML6075_REG_UVCOMP2 0x0B
+#define VEML6075_REG_ID 0x0C
+
+#define VEML6075_UVA_A_COEF 2.22f
+#define VEML6075_UVA_B_COEF 1.33f
+#define VEML6075_UVB_C_COEF 2.95f
+#define VEML6075_UVB_D_COEF 1.74f
+#define VEML6075_UVA_RESP 0.001461f
+#define VEML6075_UVB_RESP 0.002591f
+#define VEML6075_UV_INDEX_MAX 11.0f
+
+#define BH1750_CONVERSION_FACTOR 1.2f
+
+static const TickType_t BH1750_MEAS_DELAY_TICKS = pdMS_TO_TICKS(180);
 
 static const char *TAG = "sensors_real";
 static i2c_master_dev_handle_t sht31_dev = NULL;
 static i2c_master_dev_handle_t tmp117_dev = NULL;
+static i2c_master_dev_handle_t bh1750_dev = NULL;
+static i2c_master_dev_handle_t veml6075_dev = NULL;
+
+static esp_err_t bh1750_init(void)
+{
+    const uint8_t addresses[] = {BH1750_ADDR_LOW, BH1750_ADDR_HIGH};
+    for (size_t i = 0; i < sizeof(addresses) / sizeof(addresses[0]); ++i) {
+        if (DEV_I2C_Probe(addresses[i]) != ESP_OK) {
+            continue;
+        }
+        esp_err_t ret = DEV_I2C_Set_Slave_Addr(&bh1750_dev, addresses[i]);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to add BH1750 at 0x%02X: %s", addresses[i], esp_err_to_name(ret));
+            continue;
+        }
+        uint8_t cmd = BH1750_CMD_POWER_ON;
+        ret = DEV_I2C_Write_Nbyte(bh1750_dev, &cmd, 1);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to power on BH1750: %s", esp_err_to_name(ret));
+            i2c_master_bus_rm_device(bh1750_dev);
+            bh1750_dev = NULL;
+            continue;
+        }
+        cmd = BH1750_CMD_RESET;
+        ret = DEV_I2C_Write_Nbyte(bh1750_dev, &cmd, 1);
+        if (ret != ESP_OK) {
+            ESP_LOGW(TAG, "BH1750 reset command failed: %s", esp_err_to_name(ret));
+        }
+        return ESP_OK;
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+static esp_err_t veml6075_init(void)
+{
+    if (DEV_I2C_Probe(VEML6075_ADDR) != ESP_OK) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    esp_err_t ret = DEV_I2C_Set_Slave_Addr(&veml6075_dev, VEML6075_ADDR);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add VEML6075: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    uint8_t cfg[3] = {
+        VEML6075_REG_CONF,
+        (uint8_t)(VEML6075_DEFAULT_CONF & 0xFF),
+        (uint8_t)((VEML6075_DEFAULT_CONF >> 8) & 0xFF),
+    };
+    ret = DEV_I2C_Write_Nbyte(veml6075_dev, cfg, sizeof(cfg));
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to configure VEML6075: %s", esp_err_to_name(ret));
+        i2c_master_bus_rm_device(veml6075_dev);
+        veml6075_dev = NULL;
+        return ret;
+    }
+
+    uint8_t id_buf[2] = {0};
+    ret = DEV_I2C_Read_Nbyte(veml6075_dev, VEML6075_REG_ID, id_buf, sizeof(id_buf));
+    if (ret == ESP_OK) {
+        uint16_t id = (uint16_t)id_buf[0] | ((uint16_t)id_buf[1] << 8);
+        if ((id & 0xFF) != 0x26) {
+            ESP_LOGW(TAG, "Unexpected VEML6075 ID: 0x%04X", id);
+        }
+    } else {
+        ESP_LOGW(TAG, "Unable to read VEML6075 ID: %s", esp_err_to_name(ret));
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t veml6075_read16(uint8_t reg, uint16_t *value)
+{
+    if (!value) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    uint8_t buf[2] = {0};
+    esp_err_t ret = DEV_I2C_Read_Nbyte(veml6075_dev, reg, buf, sizeof(buf));
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "VEML6075 reg 0x%02X read failed: %s", reg, esp_err_to_name(ret));
+        return ret;
+    }
+    *value = (uint16_t)buf[0] | ((uint16_t)buf[1] << 8);
+    return ESP_OK;
+}
 
 static esp_err_t sensors_real_init(void)
 {
@@ -39,6 +152,18 @@ static esp_err_t sensors_real_init(void)
         any_device = true;
     } else {
         tmp117_dev = NULL;
+    }
+
+    if (bh1750_init() == ESP_OK) {
+        any_device = true;
+    } else {
+        bh1750_dev = NULL;
+    }
+
+    if (veml6075_init() == ESP_OK) {
+        any_device = true;
+    } else {
+        veml6075_dev = NULL;
     }
 
     if (!any_device) {
@@ -101,6 +226,83 @@ static float sensors_real_read_humidity(void)
     return 100.0f * ((float)raw_hum / 65535.0f);
 }
 
+static float sensors_real_read_lux(void)
+{
+    if (bh1750_dev == NULL) {
+        return NAN;
+    }
+
+    uint8_t cmd = BH1750_CMD_ONE_TIME_HIGH_RES;
+    if (DEV_I2C_Write_Nbyte(bh1750_dev, &cmd, 1) != ESP_OK) {
+        return NAN;
+    }
+
+    vTaskDelay(BH1750_MEAS_DELAY_TICKS);
+
+    uint8_t buf[2] = {0};
+    esp_err_t ret = i2c_master_receive(bh1750_dev, buf, sizeof(buf), 100);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "BH1750 read failed: %s", esp_err_to_name(ret));
+        return NAN;
+    }
+
+    uint16_t raw = ((uint16_t)buf[0] << 8) | buf[1];
+    float lux = (float)raw / BH1750_CONVERSION_FACTOR;
+    if (lux < 0.0f) {
+        lux = 0.0f;
+    }
+    return lux;
+}
+
+static sensor_uv_data_t sensors_real_read_uv(void)
+{
+    sensor_uv_data_t data = {
+        .uva = NAN,
+        .uvb = NAN,
+        .uv_index = NAN,
+    };
+
+    if (veml6075_dev == NULL) {
+        return data;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(100));
+
+    uint16_t raw_uva = 0;
+    uint16_t raw_uvb = 0;
+    uint16_t raw_comp1 = 0;
+    uint16_t raw_comp2 = 0;
+
+    if (veml6075_read16(VEML6075_REG_UVA, &raw_uva) != ESP_OK ||
+        veml6075_read16(VEML6075_REG_UVB, &raw_uvb) != ESP_OK ||
+        veml6075_read16(VEML6075_REG_UVCOMP1, &raw_comp1) != ESP_OK ||
+        veml6075_read16(VEML6075_REG_UVCOMP2, &raw_comp2) != ESP_OK) {
+        return data;
+    }
+
+    float uva_calc = (float)raw_uva - (VEML6075_UVA_A_COEF * (float)raw_comp1) - (VEML6075_UVA_B_COEF * (float)raw_comp2);
+    float uvb_calc = (float)raw_uvb - (VEML6075_UVB_C_COEF * (float)raw_comp1) - (VEML6075_UVB_D_COEF * (float)raw_comp2);
+
+    if (uva_calc < 0.0f) {
+        uva_calc = 0.0f;
+    }
+    if (uvb_calc < 0.0f) {
+        uvb_calc = 0.0f;
+    }
+
+    data.uva = uva_calc * VEML6075_UVA_RESP;
+    data.uvb = uvb_calc * VEML6075_UVB_RESP;
+    data.uv_index = (data.uva + data.uvb) * 0.5f;
+
+    if (data.uv_index < 0.0f) {
+        data.uv_index = 0.0f;
+    } else if (data.uv_index > VEML6075_UV_INDEX_MAX) {
+        data.uv_index = VEML6075_UV_INDEX_MAX;
+    }
+
+    return data;
+}
+
 static void sensors_real_deinit(void)
 {
     if (sht31_dev) {
@@ -111,12 +313,22 @@ static void sensors_real_deinit(void)
         i2c_master_bus_rm_device(tmp117_dev);
         tmp117_dev = NULL;
     }
+    if (bh1750_dev) {
+        i2c_master_bus_rm_device(bh1750_dev);
+        bh1750_dev = NULL;
+    }
+    if (veml6075_dev) {
+        i2c_master_bus_rm_device(veml6075_dev);
+        veml6075_dev = NULL;
+    }
 }
 
 const sensor_driver_t sensors_real_driver = {
     .init = sensors_real_init,
     .read_temperature = sensors_real_read_temperature,
     .read_humidity = sensors_real_read_humidity,
+    .read_lux = sensors_real_read_lux,
+    .read_uv = sensors_real_read_uv,
     .deinit = sensors_real_deinit,
 };
 

--- a/components/sensors/sensors_sim.c
+++ b/components/sensors/sensors_sim.c
@@ -4,6 +4,12 @@
 
 static float s_temp = NAN;
 static float s_hum = NAN;
+static float s_lux = NAN;
+static sensor_uv_data_t s_uv = {
+    .uva = NAN,
+    .uvb = NAN,
+    .uv_index = NAN,
+};
 
 static esp_err_t sensors_sim_init(void)
 {
@@ -28,10 +34,38 @@ static float sensors_sim_read_humidity(void)
     return 40.0f + (float)(randv % 200) / 10.0f;
 }
 
+static float sensors_sim_read_lux(void)
+{
+    if (!isnan(s_lux)) {
+        return s_lux;
+    }
+    uint32_t randv = esp_random();
+    return 300.0f + (float)(randv % 700);
+}
+
+static sensor_uv_data_t sensors_sim_read_uv(void)
+{
+    if (!isnan(s_uv.uv_index)) {
+        return s_uv;
+    }
+    uint32_t randv = esp_random();
+    float index = 2.0f + (float)(randv % 30) / 10.0f; // 2.0 - 4.9
+    sensor_uv_data_t data = {
+        .uv_index = index,
+        .uva = index * 0.6f,
+        .uvb = index * 0.4f,
+    };
+    return data;
+}
+
 static void sensors_sim_deinit(void)
 {
     s_temp = NAN;
     s_hum = NAN;
+    s_lux = NAN;
+    s_uv.uva = NAN;
+    s_uv.uvb = NAN;
+    s_uv.uv_index = NAN;
 }
 
 void sensors_sim_set_temperature(float temp)
@@ -44,10 +78,28 @@ void sensors_sim_set_humidity(float hum)
     s_hum = hum;
 }
 
+void sensors_sim_set_lux(float lux)
+{
+    s_lux = lux;
+}
+
+void sensors_sim_set_uv(float uva, float uvb)
+{
+    s_uv.uva = uva;
+    s_uv.uvb = uvb;
+    if (isnan(uva) || isnan(uvb)) {
+        s_uv.uv_index = NAN;
+    } else {
+        s_uv.uv_index = (uva + uvb) * 0.5f;
+    }
+}
+
 const sensor_driver_t sensors_sim_driver = {
     .init = sensors_sim_init,
     .read_temperature = sensors_sim_read_temperature,
     .read_humidity = sensors_sim_read_humidity,
+    .read_lux = sensors_sim_read_lux,
+    .read_uv = sensors_sim_read_uv,
     .deinit = sensors_sim_deinit,
 };
 

--- a/components/sim_api/sim_api.h
+++ b/components/sim_api/sim_api.h
@@ -6,6 +6,8 @@
 
 void sensors_sim_set_temperature(float temp);
 void sensors_sim_set_humidity(float hum);
+void sensors_sim_set_lux(float lux);
+void sensors_sim_set_uv(float uva, float uvb);
 
 bool gpio_sim_get_heater_state(void);
 bool gpio_sim_get_pump_state(void);

--- a/main/reptile_real.c
+++ b/main/reptile_real.c
@@ -7,163 +7,495 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "settings.h"
+#include "esp_log.h"
 #include <math.h>
 
+#define CHART_POINT_COUNT          60
+#define SENSOR_POLL_PERIOD_MS      1000
+#define LUX_METER_MAX              2000.0f
+#define UV_INDEX_METER_MAX         12.0f
+#define TEMP_MIN_DISPLAY           -10.0f
+#define TEMP_MAX_DISPLAY           60.0f
+#define HUMIDITY_MIN_DISPLAY       0.0f
+#define HUMIDITY_MAX_DISPLAY       100.0f
+#define SENSOR_TASK_STACK_SIZE     4096
+#define SENSOR_TASK_PRIORITY       5
+
+static const char *TAG = "reptile_real";
+
 static void feed_task(void *arg);
+static void sensor_poll_task(void *arg);
 static void env_state_cb(const reptile_env_state_t *state, void *ctx);
+static void pump_btn_cb(lv_event_t *e);
+static void heat_btn_cb(lv_event_t *e);
+static void feed_btn_cb(lv_event_t *e);
+static void fan_btn_cb(lv_event_t *e);
+static void uv_btn_cb(lv_event_t *e);
+static void light_btn_cb(lv_event_t *e);
+static void menu_btn_cb(lv_event_t *e);
+static void update_status_labels(void);
+static void update_sensor_widgets(float temp, float hum, float lux, sensor_uv_data_t uv);
+static lv_obj_t *create_action_row(lv_obj_t *parent,
+                                   lv_obj_t **label_out,
+                                   const char *initial_text,
+                                   const char *btn_text,
+                                   lv_event_cb_t cb);
 
 static lv_obj_t *screen;
 static lv_obj_t *label_temp;
 static lv_obj_t *label_hum;
+static lv_obj_t *label_lux;
+static lv_obj_t *label_uv;
 static lv_obj_t *label_pump;
 static lv_obj_t *label_heat;
 static lv_obj_t *label_feed;
+static lv_obj_t *label_fan;
+static lv_obj_t *label_uv_lamp;
+static lv_obj_t *label_light;
+static lv_obj_t *chart;
+static lv_chart_series_t *chart_series_temp;
+static lv_chart_series_t *chart_series_hum;
+static lv_obj_t *sensor_meter;
+static lv_meter_scale_t *meter_scale_lux;
+static lv_meter_scale_t *meter_scale_uv;
+static lv_meter_indicator_t *needle_lux;
+static lv_meter_indicator_t *needle_uv;
 static volatile bool feed_running;
 static TaskHandle_t feed_task_handle;
+static TaskHandle_t sensor_task_handle;
+static TaskHandle_t sensor_task_waiter;
+static volatile bool sensor_task_running;
+static volatile bool sensor_ui_ready;
 static reptile_env_state_t s_env_state;
+static volatile bool fan_on;
+static volatile bool uv_lamp_on;
+static volatile bool light_on;
 
 extern lv_obj_t *menu_screen;
 
-static void update_status_labels(void) {
-  if (isnan(s_env_state.temperature))
-    lv_label_set_text(label_temp, "Temp\u00e9rature: Non connect\u00e9");
-  else
-    lv_label_set_text_fmt(label_temp, "Temp\u00e9rature: %.1f \u00b0C", s_env_state.temperature);
-  if (isnan(s_env_state.humidity))
-    lv_label_set_text(label_hum, "Humidit\u00e9: Non connect\u00e9");
-  else
-    lv_label_set_text_fmt(label_hum, "Humidit\u00e9: %.1f %%", s_env_state.humidity);
-  lv_label_set_text(label_pump, s_env_state.pumping ? "Pompe: ON" : "Pompe: OFF");
-  lv_label_set_text(label_heat, s_env_state.heating ? "Chauffage: ON" : "Chauffage: OFF");
-  lv_label_set_text(label_feed, feed_running ? "Nourrissage: ON" : "Nourrissage: OFF");
+static lv_obj_t *create_action_row(lv_obj_t *parent,
+                                   lv_obj_t **label_out,
+                                   const char *initial_text,
+                                   const char *btn_text,
+                                   lv_event_cb_t cb)
+{
+    lv_obj_t *row = lv_obj_create(parent);
+    lv_obj_remove_style_all(row);
+    lv_obj_set_size(row, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_style_pad_gap(row, 8, 0);
+    lv_obj_set_style_pad_all(row, 0, 0);
+
+    *label_out = lv_label_create(row);
+    lv_obj_set_flex_grow(*label_out, 1);
+    lv_label_set_text(*label_out, initial_text);
+
+    lv_obj_t *btn = lv_btn_create(row);
+    lv_obj_t *lbl = lv_label_create(btn);
+    lv_label_set_text(lbl, btn_text);
+    lv_obj_center(lbl);
+    lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, NULL);
+    return row;
 }
 
-static void env_state_cb(const reptile_env_state_t *state, void *ctx) {
-  (void)ctx;
-  s_env_state = *state;
-  if (lvgl_port_lock(-1)) {
-    update_status_labels();
-    lvgl_port_unlock();
-  }
-}
-
-
-static void feed_task(void *arg) {
-  (void)arg;
-  feed_running = true;
-  if (lvgl_port_lock(-1)) {
-    update_status_labels();
-    lvgl_port_unlock();
-  }
-  reptile_feed_gpio();
-  feed_running = false;
-  if (lvgl_port_lock(-1)) {
-    update_status_labels();
-    lvgl_port_unlock();
-  }
-  feed_task_handle = NULL;
-  vTaskDelete(NULL);
-}
-
-static void pump_btn_cb(lv_event_t *e) {
-  (void)e;
-  reptile_env_manual_pump();
-}
-
-static void heat_btn_cb(lv_event_t *e) {
-  (void)e;
-  reptile_env_manual_heat();
-}
-
-static void feed_btn_cb(lv_event_t *e) {
-  (void)e;
-  if (!feed_running)
-    xTaskCreate(feed_task, "feed_task", 2048, NULL, 5, &feed_task_handle);
-}
-
-static void menu_btn_cb(lv_event_t *e) {
-  (void)e;
-  reptile_env_stop();
-  sensors_deinit();
-  if (feed_task_handle) {
-    vTaskDelete(feed_task_handle);
-    feed_task_handle = NULL;
-  }
-  feed_running = false;
-  reptile_actuators_deinit();
-
-  if (lvgl_port_lock(-1)) {
-    lv_scr_load(menu_screen);
-    if (screen) {
-      lv_obj_del(screen);
-      screen = NULL;
+static void update_status_labels(void)
+{
+    if (!label_temp || !label_hum) {
+        return;
     }
+
+    if (isnan(s_env_state.temperature)) {
+        lv_label_set_text(label_temp, "Température: Non connecté");
+    } else {
+        lv_label_set_text_fmt(label_temp, "Température: %.1f °C", s_env_state.temperature);
+    }
+
+    if (isnan(s_env_state.humidity)) {
+        lv_label_set_text(label_hum, "Humidité: Non connecté");
+    } else {
+        lv_label_set_text_fmt(label_hum, "Humidité: %.1f %%", s_env_state.humidity);
+    }
+
+    if (label_pump) {
+        lv_label_set_text(label_pump, s_env_state.pumping ? "Pompe: ON" : "Pompe: OFF");
+    }
+    if (label_heat) {
+        lv_label_set_text(label_heat, s_env_state.heating ? "Chauffage: ON" : "Chauffage: OFF");
+    }
+    if (label_feed) {
+        lv_label_set_text(label_feed, feed_running ? "Nourrissage: ON" : "Nourrissage: OFF");
+    }
+    if (label_fan) {
+        lv_label_set_text(label_fan, fan_on ? "Ventilateur: ON" : "Ventilateur: OFF");
+    }
+    if (label_uv_lamp) {
+        lv_label_set_text(label_uv_lamp, uv_lamp_on ? "Lampe UV: ON" : "Lampe UV: OFF");
+    }
+    if (label_light) {
+        lv_label_set_text(label_light, light_on ? "Éclairage: ON" : "Éclairage: OFF");
+    }
+}
+
+static void update_sensor_widgets(float temp, float hum, float lux, sensor_uv_data_t uv)
+{
+    if (chart) {
+        if (chart_series_temp) {
+            if (isnan(temp)) {
+                lv_chart_set_next_value(chart, chart_series_temp, LV_CHART_POINT_NONE);
+            } else {
+                float clamped = fminf(fmaxf(temp, TEMP_MIN_DISPLAY), TEMP_MAX_DISPLAY);
+                lv_chart_set_next_value(chart, chart_series_temp, (lv_coord_t)clamped);
+            }
+        }
+        if (chart_series_hum) {
+            if (isnan(hum)) {
+                lv_chart_set_next_value(chart, chart_series_hum, LV_CHART_POINT_NONE);
+            } else {
+                float clamped = fminf(fmaxf(hum, HUMIDITY_MIN_DISPLAY), HUMIDITY_MAX_DISPLAY);
+                lv_chart_set_next_value(chart, chart_series_hum, (lv_coord_t)clamped);
+            }
+        }
+        lv_chart_refresh(chart);
+    }
+
+    if (label_lux) {
+        if (isnan(lux)) {
+            lv_label_set_text(label_lux, "Luminosité: Non connectée");
+        } else {
+            lv_label_set_text_fmt(label_lux, "Luminosité: %.0f lx", lux);
+        }
+    }
+
+    if (label_uv) {
+        if (isnan(uv.uv_index)) {
+            lv_label_set_text(label_uv, "UV: Non connectés");
+        } else {
+            float uva = isnan(uv.uva) ? 0.0f : uv.uva;
+            float uvb = isnan(uv.uvb) ? 0.0f : uv.uvb;
+            lv_label_set_text_fmt(label_uv,
+                                  "UV index: %.2f (UVA %.3f / UVB %.3f)",
+                                  uv.uv_index,
+                                  uva,
+                                  uvb);
+        }
+    }
+
+    if (sensor_meter) {
+        if (needle_lux) {
+            lv_coord_t lux_value = 0;
+            if (!isnan(lux)) {
+                float clamped = fminf(fmaxf(lux, 0.0f), LUX_METER_MAX);
+                lux_value = (lv_coord_t)clamped;
+            }
+            lv_meter_set_indicator_value(sensor_meter, needle_lux, lux_value);
+        }
+        if (needle_uv) {
+            lv_coord_t uv_value = 0;
+            if (!isnan(uv.uv_index)) {
+                float clamped = fminf(fmaxf(uv.uv_index, 0.0f), UV_INDEX_METER_MAX);
+                uv_value = (lv_coord_t)clamped;
+            }
+            lv_meter_set_indicator_value(sensor_meter, needle_uv, uv_value);
+        }
+    }
+}
+
+static void env_state_cb(const reptile_env_state_t *state, void *ctx)
+{
+    (void)ctx;
+    s_env_state = *state;
+    if (lvgl_port_lock(-1)) {
+        update_status_labels();
+        lvgl_port_unlock();
+    }
+}
+
+static void feed_task(void *arg)
+{
+    (void)arg;
+    feed_running = true;
+    if (lvgl_port_lock(-1)) {
+        update_status_labels();
+        lvgl_port_unlock();
+    }
+    reptile_feed_gpio();
+    feed_running = false;
+    if (lvgl_port_lock(-1)) {
+        update_status_labels();
+        lvgl_port_unlock();
+    }
+    feed_task_handle = NULL;
+    vTaskDelete(NULL);
+}
+
+static void pump_btn_cb(lv_event_t *e)
+{
+    (void)e;
+    reptile_env_manual_pump();
+}
+
+static void heat_btn_cb(lv_event_t *e)
+{
+    (void)e;
+    reptile_env_manual_heat();
+}
+
+static void feed_btn_cb(lv_event_t *e)
+{
+    (void)e;
+    if (!feed_running) {
+        xTaskCreate(feed_task, "feed_task", 2048, NULL, 5, &feed_task_handle);
+    }
+}
+
+static void fan_btn_cb(lv_event_t *e)
+{
+    (void)e;
+    fan_on = !fan_on;
+    reptile_fan_set(fan_on);
+    fan_on = reptile_fan_get();
+    update_status_labels();
+}
+
+static void uv_btn_cb(lv_event_t *e)
+{
+    (void)e;
+    uv_lamp_on = !uv_lamp_on;
+    reptile_uv_lamp_set(uv_lamp_on);
+    uv_lamp_on = reptile_uv_lamp_get();
+    update_status_labels();
+}
+
+static void light_btn_cb(lv_event_t *e)
+{
+    (void)e;
+    light_on = !light_on;
+    reptile_light_set(light_on);
+    light_on = reptile_light_get();
+    update_status_labels();
+}
+
+static void sensor_poll_task(void *arg)
+{
+    (void)arg;
+    const TickType_t delay = pdMS_TO_TICKS(SENSOR_POLL_PERIOD_MS);
+
+    while (sensor_task_running) {
+        float temp = sensors_read_temperature();
+        float hum = sensors_read_humidity();
+        float lux = sensors_read_lux();
+        sensor_uv_data_t uv = sensors_read_uv();
+
+        if (!sensor_task_running) {
+            break;
+        }
+
+        if (lvgl_port_lock(-1)) {
+            if (sensor_ui_ready) {
+                update_sensor_widgets(temp, hum, lux, uv);
+            }
+            lvgl_port_unlock();
+        }
+
+        if (!sensor_task_running) {
+            break;
+        }
+
+        (void)ulTaskNotifyTake(pdTRUE, delay);
+    }
+
+    sensor_task_running = false;
+    if (sensor_task_waiter) {
+        xTaskNotifyGive(sensor_task_waiter);
+        sensor_task_waiter = NULL;
+    }
+    sensor_task_handle = NULL;
+    vTaskDelete(NULL);
+}
+
+static void menu_btn_cb(lv_event_t *e)
+{
+    (void)e;
+
+    sensor_ui_ready = false;
+    if (sensor_task_handle) {
+        sensor_task_waiter = xTaskGetCurrentTaskHandle();
+        sensor_task_running = false;
+        xTaskNotifyGive(sensor_task_handle);
+        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(SENSOR_POLL_PERIOD_MS + 200));
+        sensor_task_waiter = NULL;
+    }
+
+    reptile_env_stop();
+    sensors_deinit();
+
+    if (feed_task_handle) {
+        vTaskDelete(feed_task_handle);
+        feed_task_handle = NULL;
+    }
+    feed_running = false;
+
+    reptile_fan_set(false);
+    reptile_uv_lamp_set(false);
+    reptile_light_set(false);
+    fan_on = false;
+    uv_lamp_on = false;
+    light_on = false;
+
+    reptile_actuators_deinit();
+
+    if (lvgl_port_lock(-1)) {
+        lv_scr_load(menu_screen);
+        if (screen) {
+            lv_obj_del(screen);
+            screen = NULL;
+        }
+        lvgl_port_unlock();
+    }
+}
+
+void reptile_real_start(esp_lcd_panel_handle_t panel, esp_lcd_touch_handle_t tp)
+{
+    (void)panel;
+    (void)tp;
+
+    if (!lvgl_port_lock(-1)) {
+        return;
+    }
+
+    screen = lv_obj_create(NULL);
+    lv_obj_set_style_pad_all(screen, 12, 0);
+    lv_obj_set_style_pad_gap(screen, 12, 0);
+    lv_obj_set_flex_flow(screen, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(screen, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    lv_obj_t *status_cont = lv_obj_create(screen);
+    lv_obj_remove_style_all(status_cont);
+    lv_obj_set_size(status_cont, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(status_cont, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_gap(status_cont, 6, 0);
+    lv_obj_set_style_pad_all(status_cont, 0, 0);
+
+    label_temp = lv_label_create(status_cont);
+    lv_label_set_text(label_temp, "Température: Non connecté");
+    label_hum = lv_label_create(status_cont);
+    lv_label_set_text(label_hum, "Humidité: Non connecté");
+    label_lux = lv_label_create(status_cont);
+    lv_label_set_text(label_lux, "Luminosité: Non connectée");
+    label_uv = lv_label_create(status_cont);
+    lv_label_set_text(label_uv, "UV: Non connectés");
+
+    create_action_row(status_cont, &label_pump, "Pompe: OFF", "Pompe", pump_btn_cb);
+    create_action_row(status_cont, &label_heat, "Chauffage: OFF", "Chauffage", heat_btn_cb);
+    create_action_row(status_cont, &label_feed, "Nourrissage: OFF", "Nourrir", feed_btn_cb);
+    create_action_row(status_cont, &label_fan, "Ventilateur: OFF", "Ventilateur", fan_btn_cb);
+    create_action_row(status_cont, &label_uv_lamp, "Lampe UV: OFF", "Lampe UV", uv_btn_cb);
+    create_action_row(status_cont, &label_light, "Éclairage: OFF", "Éclairage", light_btn_cb);
+
+    lv_obj_t *data_cont = lv_obj_create(screen);
+    lv_obj_remove_style_all(data_cont);
+    lv_obj_set_size(data_cont, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(data_cont, LV_FLEX_FLOW_ROW);
+    lv_obj_set_style_pad_gap(data_cont, 12, 0);
+    lv_obj_set_style_pad_all(data_cont, 0, 0);
+
+    lv_obj_t *chart_cont = lv_obj_create(data_cont);
+    lv_obj_remove_style_all(chart_cont);
+    lv_obj_set_flex_flow(chart_cont, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_gap(chart_cont, 8, 0);
+    lv_obj_set_style_pad_all(chart_cont, 0, 0);
+    lv_obj_set_flex_grow(chart_cont, 1);
+
+    lv_obj_t *chart_title = lv_label_create(chart_cont);
+    lv_label_set_text(chart_title, "Température & Humidité");
+
+    chart = lv_chart_create(chart_cont);
+    lv_obj_set_height(chart, 160);
+    lv_chart_set_type(chart, LV_CHART_TYPE_LINE);
+    lv_chart_set_update_mode(chart, LV_CHART_UPDATE_MODE_SHIFT);
+    lv_chart_set_point_count(chart, CHART_POINT_COUNT);
+    lv_chart_set_range(chart, LV_CHART_AXIS_PRIMARY_Y, (lv_coord_t)TEMP_MIN_DISPLAY, (lv_coord_t)HUMIDITY_MAX_DISPLAY);
+    chart_series_temp = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_RED), LV_CHART_AXIS_PRIMARY_Y);
+    chart_series_hum = lv_chart_add_series(chart, lv_palette_main(LV_PALETTE_BLUE), LV_CHART_AXIS_PRIMARY_Y);
+    lv_chart_set_all_value(chart, chart_series_temp, LV_CHART_POINT_NONE);
+    lv_chart_set_all_value(chart, chart_series_hum, LV_CHART_POINT_NONE);
+
+    lv_obj_t *meter_cont = lv_obj_create(data_cont);
+    lv_obj_remove_style_all(meter_cont);
+    lv_obj_set_flex_flow(meter_cont, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_gap(meter_cont, 8, 0);
+    lv_obj_set_style_pad_all(meter_cont, 0, 0);
+    lv_obj_set_flex_grow(meter_cont, 1);
+
+    lv_obj_t *meter_title = lv_label_create(meter_cont);
+    lv_label_set_text(meter_title, "Luminosité & UV");
+
+    sensor_meter = lv_meter_create(meter_cont);
+    lv_obj_set_size(sensor_meter, 200, 200);
+
+    meter_scale_lux = lv_meter_add_scale(sensor_meter);
+    lv_meter_set_scale_ticks(sensor_meter, meter_scale_lux, 21, 2, 10, lv_palette_main(LV_PALETTE_AMBER));
+    lv_meter_set_scale_major_ticks(sensor_meter, meter_scale_lux, 4, 4, 15, lv_palette_main(LV_PALETTE_AMBER), 10);
+    lv_meter_set_scale_range(sensor_meter, meter_scale_lux, 0, (lv_coord_t)LUX_METER_MAX, 270, 90);
+    needle_lux = lv_meter_add_needle_line(sensor_meter, meter_scale_lux, 6, lv_palette_main(LV_PALETTE_AMBER), -12);
+
+    meter_scale_uv = lv_meter_add_scale(sensor_meter);
+    lv_meter_set_scale_ticks(sensor_meter, meter_scale_uv, 13, 2, 10, lv_palette_main(LV_PALETTE_PURPLE));
+    lv_meter_set_scale_major_ticks(sensor_meter, meter_scale_uv, 4, 4, 15, lv_palette_main(LV_PALETTE_PURPLE), 10);
+    lv_meter_set_scale_range(sensor_meter, meter_scale_uv, 0, (lv_coord_t)UV_INDEX_METER_MAX, 270, 90);
+    needle_uv = lv_meter_add_needle_line(sensor_meter, meter_scale_uv, 4, lv_palette_main(LV_PALETTE_PURPLE), 12);
+
+    lv_obj_t *footer = lv_obj_create(screen);
+    lv_obj_remove_style_all(footer);
+    lv_obj_set_size(footer, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW);
+    lv_obj_set_style_pad_all(footer, 0, 0);
+
+    lv_obj_t *btn_menu = lv_btn_create(footer);
+    lv_obj_set_width(btn_menu, LV_PCT(100));
+    lv_obj_t *lbl_menu = lv_label_create(btn_menu);
+    lv_label_set_text(lbl_menu, "Menu");
+    lv_obj_center(lbl_menu);
+    lv_obj_add_event_cb(btn_menu, menu_btn_cb, LV_EVENT_CLICKED, NULL);
+
+    s_env_state.temperature = NAN;
+    s_env_state.humidity = NAN;
+    s_env_state.heating = false;
+    s_env_state.pumping = false;
+    feed_running = false;
+
+    fan_on = reptile_fan_get();
+    uv_lamp_on = reptile_uv_lamp_get();
+    light_on = reptile_light_get();
+
+    update_status_labels();
+    sensor_uv_data_t uv_init = {
+        .uva = NAN,
+        .uvb = NAN,
+        .uv_index = NAN,
+    };
+    update_sensor_widgets(NAN, NAN, NAN, uv_init);
+
+    lv_disp_load_scr(screen);
     lvgl_port_unlock();
-  }
+
+    reptile_env_thresholds_t thr = {
+        .temp_setpoint = g_settings.temp_threshold,
+        .humidity_setpoint = g_settings.humidity_threshold,
+    };
+    reptile_env_start(&thr, env_state_cb, NULL);
+
+    sensor_task_waiter = NULL;
+    sensor_ui_ready = true;
+    sensor_task_running = true;
+    if (xTaskCreate(sensor_poll_task,
+                    "sensor_poll",
+                    SENSOR_TASK_STACK_SIZE,
+                    NULL,
+                    SENSOR_TASK_PRIORITY,
+                    &sensor_task_handle) != pdPASS) {
+        ESP_LOGE(TAG, "Failed to start sensor polling task");
+        sensor_task_handle = NULL;
+        sensor_task_running = false;
+    }
 }
-
-void reptile_real_start(esp_lcd_panel_handle_t panel, esp_lcd_touch_handle_t tp) {
-  (void)panel;
-  (void)tp;
-
-  if (!lvgl_port_lock(-1))
-    return;
-
-  screen = lv_obj_create(NULL);
-
-  label_temp = lv_label_create(screen);
-  lv_obj_align(label_temp, LV_ALIGN_TOP_LEFT, 10, 10);
-
-  label_hum = lv_label_create(screen);
-  lv_obj_align(label_hum, LV_ALIGN_TOP_LEFT, 10, 40);
-
-  label_pump = lv_label_create(screen);
-  lv_obj_align(label_pump, LV_ALIGN_TOP_LEFT, 10, 80);
-  lv_obj_t *btn_pump = lv_btn_create(screen);
-  lv_obj_align(btn_pump, LV_ALIGN_TOP_RIGHT, -10, 75);
-  lv_obj_t *lbl = lv_label_create(btn_pump);
-  lv_label_set_text(lbl, "Pompe");
-  lv_obj_center(lbl);
-  lv_obj_add_event_cb(btn_pump, pump_btn_cb, LV_EVENT_CLICKED, NULL);
-
-  label_heat = lv_label_create(screen);
-  lv_obj_align(label_heat, LV_ALIGN_TOP_LEFT, 10, 120);
-  lv_obj_t *btn_heat = lv_btn_create(screen);
-  lv_obj_align(btn_heat, LV_ALIGN_TOP_RIGHT, -10, 115);
-  lbl = lv_label_create(btn_heat);
-  lv_label_set_text(lbl, "Chauffage");
-  lv_obj_center(lbl);
-  lv_obj_add_event_cb(btn_heat, heat_btn_cb, LV_EVENT_CLICKED, NULL);
-
-  label_feed = lv_label_create(screen);
-  lv_obj_align(label_feed, LV_ALIGN_TOP_LEFT, 10, 160);
-  lv_obj_t *btn_feed = lv_btn_create(screen);
-  lv_obj_align(btn_feed, LV_ALIGN_TOP_RIGHT, -10, 155);
-  lbl = lv_label_create(btn_feed);
-  lv_label_set_text(lbl, "Nourrir");
-  lv_obj_center(lbl);
-  lv_obj_add_event_cb(btn_feed, feed_btn_cb, LV_EVENT_CLICKED, NULL);
-
-  lv_obj_t *btn_menu = lv_btn_create(screen);
-  lv_obj_align(btn_menu, LV_ALIGN_BOTTOM_MID, 0, -10);
-  lbl = lv_label_create(btn_menu);
-  lv_label_set_text(lbl, "Menu");
-  lv_obj_center(lbl);
-  lv_obj_add_event_cb(btn_menu, menu_btn_cb, LV_EVENT_CLICKED, NULL);
-
-  s_env_state.temperature = NAN;
-  s_env_state.humidity = NAN;
-  s_env_state.heating = false;
-  s_env_state.pumping = false;
-  feed_running = false;
-  update_status_labels();
-  lv_disp_load_scr(screen);
-  lvgl_port_unlock();
-
-  reptile_env_thresholds_t thr = {
-      .temp_setpoint = g_settings.temp_threshold,
-      .humidity_setpoint = g_settings.humidity_threshold,
-  };
-  reptile_env_start(&thr, env_state_cb, NULL);
-}
-


### PR DESCRIPTION
## Summary
- integrate BH1750 lux and VEML6075 UV sensors on the real hardware path and expose lux/UV readings through the sensor API
- extend the actuator abstraction with fan, UV lamp, and lighting toggles for both real and simulated backends
- redesign the real-mode LVGL screen to show live charts/meters, poll sensors asynchronously, and add manual fan/UV/light controls

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c99bcc90d8832396ae82c9771f17fb