### PR TITLE
Expose species_db to reptile logic component

### DIFF
--- a/components/reptile_logic/CMakeLists.txt
+++ b/components/reptile_logic/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "reptile_logic.c"
     INCLUDE_DIRS "."
-    REQUIRES nvs_flash gpio config
+    REQUIRES nvs_flash gpio config species_db
     PRIV_REQUIRES sensors sd
 )


### PR DESCRIPTION
## Summary
- add species_db to the reptile_logic component's public REQUIRES list so its headers are visible to dependents

## Testing
- ⚠️ `idf.py reconfigure` *(fails: command not found in container image)*


------
https://chatgpt.com/codex/tasks/task_e_68c9b69aa2d08323b03f6beea632f0b1