### PR TITLE
Remove stray screen creation statements after reptile_game_start

### DIFF
--- a/main/reptile_game.c
+++ b/main/reptile_game.c
@@ -1502,7 +1502,3 @@ void reptile_game_start(esp_lcd_panel_handle_t panel,
   lv_scr_load(screen_main);
   ensure_species_profile();
 }
-
-  screen_main = lv_obj_create(NULL);
-  screen_stats = lv_obj_create(NULL);
-


### PR DESCRIPTION
## Summary
- remove the leftover screen creation statements that were placed after reptile_game_start and triggered implicit-int/redefinition diagnostics

## Testing
- idf.py build *(fails: `idf.py`: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c3052ef883238db52c502d840bdb