### PR TITLE
feat: expand reptile facility simulation and UI

### DIFF
--- a/assets/species_profiles.json
+++ b/assets/species_profiles.json
@@ -1,0 +1,52 @@
+{
+  "profiles": [
+    {
+      "id": "gecko",
+      "label": "Gecko léopard",
+      "temperature_day_c": [28, 32],
+      "temperature_night_c": [24, 27],
+      "humidity_pct": [40, 60],
+      "uv_index": [2.0, 3.5],
+      "food_per_day": 6,
+      "water_ml_per_day": 150,
+      "ticket_price_eur": 12.0,
+      "upkeep_eur_per_day": 9.0
+    },
+    {
+      "id": "python",
+      "label": "Python regius",
+      "temperature_day_c": [30, 34],
+      "temperature_night_c": [26, 28],
+      "humidity_pct": [55, 75],
+      "uv_index": [2.5, 4.0],
+      "food_per_day": 2,
+      "water_ml_per_day": 400,
+      "ticket_price_eur": 22.0,
+      "upkeep_eur_per_day": 24.0
+    },
+    {
+      "id": "tortoise",
+      "label": "Tortue d'Hermann",
+      "temperature_day_c": [27, 32],
+      "temperature_night_c": [20, 24],
+      "humidity_pct": [50, 70],
+      "uv_index": [3.0, 4.5],
+      "food_per_day": 8,
+      "water_ml_per_day": 250,
+      "ticket_price_eur": 18.0,
+      "upkeep_eur_per_day": 15.0
+    },
+    {
+      "id": "chameleon",
+      "label": "Caméléon panthère",
+      "temperature_day_c": [29, 33],
+      "temperature_night_c": [22, 25],
+      "humidity_pct": [55, 85],
+      "uv_index": [4.0, 5.5],
+      "food_per_day": 10,
+      "water_ml_per_day": 180,
+      "ticket_price_eur": 21.0,
+      "upkeep_eur_per_day": 17.0
+    }
+  ]
+}

--- a/components/image/currency_card.c
+++ b/components/image/currency_card.c
@@ -1,0 +1,15 @@
+#include "lvgl.h"
+#include "image.h"
+
+static const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST uint8_t
+    currency_card_map[] = {
+        0xA0, 0xFE,
+};
+
+const lv_image_dsc_t gImage_currency_card = {
+    .header.w = 1,
+    .header.h = 1,
+    .data_size = sizeof(currency_card_map),
+    .header.cf = LV_COLOR_FORMAT_RGB565,
+    .data = currency_card_map,
+};

--- a/components/image/image.c
+++ b/components/image/image.c
@@ -7,3 +7,6 @@ LV_IMG_DECLARE(gImage_reptile_sad);
 LV_IMG_DECLARE(gImage_reptile_manger);
 LV_IMG_DECLARE(gImage_reptile_boire);
 LV_IMG_DECLARE(gImage_reptile_chauffer);
+LV_IMG_DECLARE(gImage_terrarium_ok);
+LV_IMG_DECLARE(gImage_terrarium_alert);
+LV_IMG_DECLARE(gImage_currency_card);

--- a/components/image/image.h
+++ b/components/image/image.h
@@ -30,5 +30,8 @@ LV_IMG_DECLARE(gImage_reptile_sad);
 LV_IMG_DECLARE(gImage_reptile_manger);
 LV_IMG_DECLARE(gImage_reptile_boire);
 LV_IMG_DECLARE(gImage_reptile_chauffer);
+LV_IMG_DECLARE(gImage_terrarium_ok);
+LV_IMG_DECLARE(gImage_terrarium_alert);
+LV_IMG_DECLARE(gImage_currency_card);
 
 #endif /* __IMAGE_H */

--- a/components/image/terrarium_alert.c
+++ b/components/image/terrarium_alert.c
@@ -1,0 +1,15 @@
+#include "lvgl.h"
+#include "image.h"
+
+static const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST uint8_t
+    terrarium_alert_map[] = {
+        0x00, 0xF8,
+};
+
+const lv_image_dsc_t gImage_terrarium_alert = {
+    .header.w = 1,
+    .header.h = 1,
+    .data_size = sizeof(terrarium_alert_map),
+    .header.cf = LV_COLOR_FORMAT_RGB565,
+    .data = terrarium_alert_map,
+};

--- a/components/image/terrarium_ok.c
+++ b/components/image/terrarium_ok.c
@@ -1,0 +1,15 @@
+#include "lvgl.h"
+#include "image.h"
+
+static const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST uint8_t
+    terrarium_ok_map[] = {
+        0xE0, 0x07,
+};
+
+const lv_image_dsc_t gImage_terrarium_ok = {
+    .header.w = 1,
+    .header.h = 1,
+    .data_size = sizeof(terrarium_ok_map),
+    .header.cf = LV_COLOR_FORMAT_RGB565,
+    .data = terrarium_ok_map,
+};

--- a/components/logging/logging.h
+++ b/components/logging/logging.h
@@ -12,7 +12,7 @@ extern "C" {
  *
  * @param cb Callback returning pointer to current reptile state.
  */
-void logging_init(const reptile_t *(*cb)(void));
+void logging_init(const reptile_facility_t *(*cb)(void));
 
 /** Pause periodic logging timer. */
 void logging_pause(void);

--- a/components/reptile_logic/reptile_logic.h
+++ b/components/reptile_logic/reptile_logic.h
@@ -2,6 +2,7 @@
 #define REPTILE_LOGIC_H
 
 #include "esp_err.h"
+#include "game_mode.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <time.h>
@@ -10,40 +11,211 @@
 extern "C" {
 #endif
 
+#define REPTILE_MAX_TERRARIUMS 25U
+#define REPTILE_MAX_CERTIFICATES 6U
+#define REPTILE_NAME_MAX_LEN 32U
+#define REPTILE_CONFIG_STR_LEN 32U
+#define REPTILE_CERT_AUTH_LEN 32U
+#define REPTILE_CERT_ID_LEN 24U
+
 typedef enum {
-  REPTILE_EVENT_NONE = 0,
-  REPTILE_EVENT_MALADIE,
-  REPTILE_EVENT_CROISSANCE,
-} reptile_event_t;
+  REPTILE_GROWTH_HATCHLING = 0,
+  REPTILE_GROWTH_JUVENILE,
+  REPTILE_GROWTH_ADULT,
+  REPTILE_GROWTH_SENIOR,
+  REPTILE_GROWTH_STAGE_COUNT
+} reptile_growth_stage_t;
+
+typedef enum {
+  REPTILE_PATHOLOGY_NONE = 0,
+  REPTILE_PATHOLOGY_RESPIRATORY,
+  REPTILE_PATHOLOGY_PARASITIC,
+  REPTILE_PATHOLOGY_METABOLIC,
+} reptile_pathology_t;
+
+typedef enum {
+  REPTILE_INCIDENT_NONE = 0,
+  REPTILE_INCIDENT_CERTIFICATE_MISSING,
+  REPTILE_INCIDENT_CERTIFICATE_EXPIRED,
+  REPTILE_INCIDENT_ENVIRONMENT_OUT_OF_RANGE,
+  REPTILE_INCIDENT_AUDIT_LOCK,
+} reptile_incident_t;
+
+typedef enum {
+  REPTILE_SPECIES_GECKO = 0,
+  REPTILE_SPECIES_PYTHON,
+  REPTILE_SPECIES_TORTOISE,
+  REPTILE_SPECIES_CHAMELEON,
+  REPTILE_SPECIES_CUSTOM,
+  REPTILE_SPECIES_COUNT
+} reptile_species_id_t;
 
 typedef struct {
-  uint32_t faim;
-  uint32_t eau;
-  uint32_t temperature;
-  uint32_t humidite; /* pourcentage d'humidite */
-  uint32_t humeur;
-  reptile_event_t event;
+  char id[REPTILE_CERT_ID_LEN];
+  char authority[REPTILE_CERT_AUTH_LEN];
+  time_t issue_date;
+  time_t expiry_date;
+  bool valid;
+} reptile_certificate_t;
+
+typedef struct {
+  reptile_species_id_t id;
+  char name[REPTILE_NAME_MAX_LEN];
+  float day_temp_min;
+  float day_temp_max;
+  float night_temp_min;
+  float night_temp_max;
+  float humidity_min;
+  float humidity_max;
+  float uv_min;
+  float uv_max;
+  float growth_rate_per_hour;
+  float adult_weight_g;
+  uint32_t lifespan_days;
+  uint32_t food_per_day;
+  uint32_t water_ml_per_day;
+  int64_t ticket_price_cents;
+  int64_t upkeep_cents_per_day;
+} species_profile_t;
+
+typedef struct {
+  char substrate[REPTILE_CONFIG_STR_LEN];
+  char heating[REPTILE_CONFIG_STR_LEN];
+  char decor[REPTILE_CONFIG_STR_LEN];
+  char uv_setup[REPTILE_CONFIG_STR_LEN];
+} reptile_terrarium_config_t;
+
+typedef struct {
+  uint32_t feeders;          /**< Unités d'alimentation (insectes/rongeurs). */
+  uint32_t supplement_doses; /**< Doses de compléments. */
+  uint32_t substrate_bags;   /**< Sacs de substrat disponibles. */
+  uint32_t uv_bulbs;         /**< Tubes UV de remplacement. */
+  uint32_t decor_kits;       /**< Kits de décor. */
+  uint32_t water_reserve_l;  /**< Réserve d'eau en litres. */
+} reptile_inventory_t;
+
+typedef struct {
+  int64_t cash_cents;
+  int64_t daily_income_cents;
+  int64_t daily_expenses_cents;
+  int64_t fines_cents;
+  uint32_t days_elapsed;
+} reptile_economy_t;
+
+typedef struct {
+  bool is_daytime;
+  uint32_t day_ms;
+  uint32_t night_ms;
+  uint32_t elapsed_in_phase_ms;
+  uint32_t cycle_index;
+} reptile_day_cycle_t;
+
+typedef struct {
+  bool occupied;
+  species_profile_t species;
+  char nickname[REPTILE_NAME_MAX_LEN];
+  reptile_terrarium_config_t config;
+  reptile_certificate_t certificates[REPTILE_MAX_CERTIFICATES];
+  uint8_t certificate_count;
+
+  float temperature_c;
+  float humidity_pct;
+  float uv_index;
+  float satiety;
+  float hydration;
+  float growth;
+  reptile_growth_stage_t stage;
+  float weight_g;
+  uint32_t age_days;
+  float age_fraction;
+  float feed_debt;
+  float water_debt;
+  float uv_wear;
+
+  reptile_pathology_t pathology;
+  reptile_incident_t incident;
+  float pathology_timer_h;
+  float compliance_timer_h;
+  bool needs_maintenance;
+  bool audit_locked;
+  uint32_t maintenance_hours;
+
+  int64_t operating_cost_cents_per_day;
+  int64_t revenue_cents_per_day;
+
   time_t last_update;
-} reptile_t;
+} terrarium_t;
 
-typedef enum {
-  REPTILE_FAMINE_THRESHOLD = 30,
-  REPTILE_EAU_THRESHOLD = 30,
-  REPTILE_TEMP_THRESHOLD_LOW = 26,
-  REPTILE_TEMP_THRESHOLD_HIGH = 34,
-  REPTILE_HUMEUR_THRESHOLD = 40,
-} reptile_threshold_t;
+typedef struct {
+  terrarium_t terrariums[REPTILE_MAX_TERRARIUMS];
+  uint8_t terrarium_count;
+  reptile_inventory_t inventory;
+  reptile_economy_t economy;
+  reptile_day_cycle_t cycle;
+  bool simulation_mode;
+  bool sensors_available;
+  char slot[16];
+  game_mode_t mode;
+  uint32_t alerts_active;
+  uint32_t pathology_active;
+  uint32_t compliance_alerts;
+  uint32_t mature_count;
+  float average_growth;
+  time_t last_persist_time;
+} reptile_facility_t;
 
-esp_err_t reptile_init(reptile_t *r, bool simulation);
-void reptile_update(reptile_t *r, uint32_t elapsed_ms);
-esp_err_t reptile_load(reptile_t *r);
-esp_err_t reptile_save(reptile_t *r);
-void reptile_feed(reptile_t *r);
-void reptile_give_water(reptile_t *r);
-void reptile_heat(reptile_t *r);
-void reptile_soothe(reptile_t *r);
-reptile_event_t reptile_check_events(reptile_t *r);
-bool reptile_sensors_available(void);
+typedef struct {
+  uint32_t occupied;
+  uint32_t free_slots;
+  uint32_t pathologies;
+  uint32_t incidents;
+  uint32_t mature;
+  float avg_growth;
+} reptile_facility_metrics_t;
+
+const species_profile_t *reptile_species_get(reptile_species_id_t id);
+
+esp_err_t reptile_facility_init(reptile_facility_t *facility, bool simulation,
+                                const char *slot_name, game_mode_t mode);
+esp_err_t reptile_facility_load(reptile_facility_t *facility);
+esp_err_t reptile_facility_save(const reptile_facility_t *facility);
+esp_err_t reptile_facility_set_slot(reptile_facility_t *facility,
+                                    const char *slot_name);
+void reptile_facility_tick(reptile_facility_t *facility, uint32_t elapsed_ms);
+bool reptile_facility_sensors_available(const reptile_facility_t *facility);
+terrarium_t *reptile_facility_get_terrarium(reptile_facility_t *facility,
+                                            uint8_t index);
+const terrarium_t *reptile_facility_get_terrarium_const(
+    const reptile_facility_t *facility, uint8_t index);
+void reptile_facility_compute_metrics(const reptile_facility_t *facility,
+                                      reptile_facility_metrics_t *out);
+void reptile_facility_reset_statistics(reptile_facility_t *facility);
+
+esp_err_t reptile_terrarium_set_species(terrarium_t *terrarium,
+                                        const species_profile_t *profile,
+                                        const char *nickname);
+void reptile_terrarium_set_config(terrarium_t *terrarium,
+                                  const reptile_terrarium_config_t *config);
+esp_err_t reptile_terrarium_set_substrate(terrarium_t *terrarium,
+                                          const char *substrate);
+esp_err_t reptile_terrarium_set_heating(terrarium_t *terrarium,
+                                        const char *heating);
+esp_err_t reptile_terrarium_set_decor(terrarium_t *terrarium,
+                                      const char *decor);
+esp_err_t reptile_terrarium_set_uv(terrarium_t *terrarium, const char *uv);
+esp_err_t reptile_terrarium_add_certificate(
+    terrarium_t *terrarium, const reptile_certificate_t *certificate);
+
+void reptile_inventory_add_feed(reptile_facility_t *facility,
+                                uint32_t quantity);
+void reptile_inventory_add_substrate(reptile_facility_t *facility,
+                                     uint32_t quantity);
+void reptile_inventory_add_uv_bulbs(reptile_facility_t *facility,
+                                    uint32_t quantity);
+void reptile_inventory_add_decor(reptile_facility_t *facility,
+                                 uint32_t quantity);
+void reptile_inventory_add_water(reptile_facility_t *facility,
+                                 uint32_t liters);
 
 #ifdef __cplusplus
 }

--- a/main/reptile_game.h
+++ b/main/reptile_game.h
@@ -13,7 +13,7 @@ extern "C" {
 
 void reptile_game_init(void);
 void reptile_tick(lv_timer_t *timer);
-const reptile_t *reptile_get_state(void);
+const reptile_facility_t *reptile_get_state(void);
 void reptile_game_stop(void);
 bool reptile_game_is_active(void);
 

--- a/tests/include/esp_err.h
+++ b/tests/include/esp_err.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef int32_t esp_err_t;
+
+#define ESP_OK 0
+#define ESP_FAIL -1
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_NO_MEM 0x103
+#define ESP_ERR_NOT_FOUND 0x104
+
+static inline const char *esp_err_to_name(esp_err_t err) {
+  switch (err) {
+  case ESP_OK:
+    return "ESP_OK";
+  case ESP_FAIL:
+    return "ESP_FAIL";
+  case ESP_ERR_INVALID_ARG:
+    return "ESP_ERR_INVALID_ARG";
+  case ESP_ERR_NO_MEM:
+    return "ESP_ERR_NO_MEM";
+  case ESP_ERR_NOT_FOUND:
+    return "ESP_ERR_NOT_FOUND";
+  default:
+    return "ESP_ERR_UNKNOWN";
+  }
+}

--- a/tests/include/esp_log.h
+++ b/tests/include/esp_log.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdio.h>
+
+#define ESP_LOGI(tag, fmt, ...) fprintf(stderr, "[I][%s] " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "[W][%s] " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "[E][%s] " fmt "\n", tag, ##__VA_ARGS__)

--- a/tests/include/sd.h
+++ b/tests/include/sd.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esp_err.h"
+#include <sys/stat.h>
+
+#define MOUNT_POINT "./sdcard"
+
+static inline esp_err_t sd_mmc_init(void) {
+  mkdir(MOUNT_POINT, 0777);
+  return ESP_OK;
+}
+
+static inline esp_err_t sd_mmc_unmount(void) { return ESP_OK; }
+
+static inline esp_err_t sd_card_print_info(void) { return ESP_OK; }
+
+static inline esp_err_t read_sd_capacity(size_t *total_capacity,
+                                         size_t *available_capacity) {
+  if (total_capacity)
+    *total_capacity = 0;
+  if (available_capacity)
+    *available_capacity = 0;
+  return ESP_OK;
+}

--- a/tests/sim_reptile.c
+++ b/tests/sim_reptile.c
@@ -1,31 +1,81 @@
-#include <stdio.h>
+#include "reptile_logic.h"
 #include "game_mode.h"
-#include "sensors.h"
-#include "gpio.h"
-#include "sim_api.h"
+#include <stdio.h>
+#include <time.h>
 
-int main(void)
-{
-#ifdef GAME_MODE_SIMULATION
-    game_mode_set(GAME_MODE_SIMULATION);
-    sensors_init();
-    reptile_actuators_init();
+static const char *stage_to_str(reptile_growth_stage_t stage) {
+  switch (stage) {
+  case REPTILE_GROWTH_HATCHLING:
+    return "hatchling";
+  case REPTILE_GROWTH_JUVENILE:
+    return "juvenile";
+  case REPTILE_GROWTH_ADULT:
+    return "adult";
+  case REPTILE_GROWTH_SENIOR:
+    return "senior";
+  default:
+    return "unknown";
+  }
+}
 
-    sensors_sim_set_temperature(32.5f);
-    sensors_sim_set_humidity(65.0f);
+int main(void) {
+  reptile_facility_t facility;
+  game_mode_set(GAME_MODE_SIMULATION);
+  reptile_facility_init(&facility, true, "test_slot", GAME_MODE_SIMULATION);
 
-    float t = sensors_read_temperature();
-    float h = sensors_read_humidity();
-    printf("Temp=%.1fC Hum=%.1f%%\n", t, h);
+  reptile_facility_metrics_t metrics;
+  reptile_facility_compute_metrics(&facility, &metrics);
+  printf("Initial occupied=%u free=%u cash=%.2f€\n", metrics.occupied,
+         metrics.free_slots, facility.economy.cash_cents / 100.0);
 
-    DEV_Digital_Write(HEAT_RES_PIN, 1);
-    DEV_Digital_Write(WATER_PUMP_PIN, 1);
-    printf("Heater=%d Pump=%d\n", gpio_sim_get_heater_state(), gpio_sim_get_pump_state());
+  for (int i = 0; i < 6 * 60; ++i) {
+    reptile_facility_tick(&facility, 1000);
+  }
 
-    reptile_actuators_deinit();
-    sensors_deinit();
-#else
-    printf("Simulation mode not enabled.\n");
-#endif
-    return 0;
+  const terrarium_t *t0 = reptile_facility_get_terrarium_const(&facility, 0);
+  printf("T01 growth=%.1f%% stage=%s income=%.2f€/j incident=%d\n",
+         t0->growth * 100.0f, stage_to_str(t0->stage),
+         t0->revenue_cents_per_day / 100.0f, t0->incident);
+
+  reptile_certificate_t cert = {
+      .valid = true,
+      .issue_date = time(NULL),
+      .expiry_date = time(NULL) + 365L * 24L * 3600L,
+  };
+  snprintf(cert.id, sizeof(cert.id), "AUTO-%ld", (long)cert.issue_date);
+  snprintf(cert.authority, sizeof(cert.authority), "DDPP test");
+  reptile_terrarium_add_certificate(reptile_facility_get_terrarium(&facility, 0),
+                                    &cert);
+
+  for (int i = 0; i < 4 * 60; ++i) {
+    reptile_facility_tick(&facility, 1000);
+  }
+  printf("After certification alerts=%u compliance=%u\n",
+         facility.alerts_active, facility.compliance_alerts);
+
+  facility.terrariums[0].certificate_count = 0;
+  for (int i = 0; i < 8 * 60; ++i) {
+    reptile_facility_tick(&facility, 1000);
+  }
+  printf("Compliance incidents=%u total fines=%.2f€\n",
+         facility.compliance_alerts, facility.economy.fines_cents / 100.0);
+
+  reptile_inventory_add_feed(&facility, 20);
+  reptile_inventory_add_water(&facility, 40);
+  printf("Stocks feed=%u water=%uL cash=%.2f€\n",
+         facility.inventory.feeders, facility.inventory.water_reserve_l,
+         facility.economy.cash_cents / 100.0);
+
+  reptile_facility_save(&facility);
+
+  reptile_facility_t loaded;
+  reptile_facility_init(&loaded, true, "test_slot", GAME_MODE_SIMULATION);
+  if (reptile_facility_load(&loaded) == ESP_OK) {
+    printf("Loaded slot=%s mature=%u average_growth=%.1f%%\n", loaded.slot,
+           loaded.mature_count, loaded.average_growth * 100.0f);
+  } else {
+    printf("Failed to load saved state\n");
+  }
+
+  return 0;
 }


### PR DESCRIPTION
## Summary
- restructured the reptile logic module with facility-wide structures, persistence slots, species profiles and detailed inventory/economy simulation covering 25 terrariums【F:components/reptile_logic/reptile_logic.h†L14-L174】【F:components/reptile_logic/reptile_logic.c†L75-L720】【F:assets/species_profiles.json†L1-L52】
- rebuilt the LVGL gameplay interface to display the terrarium room grid, detailed configuration panels, economic dashboard and save/load workflow while emitting aggregated CAN telemetry【F:main/reptile_game.c†L19-L844】
- updated logging, assets and host-side tests to consume the new facility data, including lightweight LVGL icons and simulation stubs for CI-less verification【F:components/logging/logging.c†L1-L85】【F:components/image/terrarium_ok.c†L1-L15】【F:components/image/terrarium_alert.c†L1-L15】【F:components/image/currency_card.c†L1-L15】【F:tests/sim_reptile.c†L1-L80】【F:tests/include/esp_err.h†L1-L28】
- refreshed the README with a description of the new gameplay loop, persistence layout, host test flow and revised CAN payload【F:README.md†L8-L124】【F:README.md†L146-L157】

## Testing
- `gcc tests/sim_reptile.c components/reptile_logic/reptile_logic.c components/config/game_mode.c -Itests/include -Icomponents/reptile_logic -Icomponents/config -lm -o sim_reptile && ./sim_reptile`【e60ff0†L1-L11】

------
https://chatgpt.com/codex/tasks/task_e_68c9cba5211883238ae2050e20a1e0a6