### PR TITLE
Add regulatory compliance engine, LVGL obligations UI, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ contrôleur tactile capacitif GT911 gère l'interaction utilisateur.
   réglementaires.
 - Modèle économique détaillé (revenus, charges, amendes, inventaire) et API pour
   configurer substrat, chauffage, décor, UV et certificats.
+- Référentiel réglementaire structuré (autorisations, certificats, registres,
+  dimensions minimales) avec validation automatique des actions et écran LVGL
+  pédagogique.
 - Refonte totale de l'UI LVGL (vue pièce, fiche terrarium, synthèse économique,
   gestion des sauvegardes) et nouveaux assets LVGL.
 
@@ -49,6 +52,28 @@ Le moteur met à jour chaque seconde :
   pathologies éventuelles ;
 - la conformité documentaire (certificats CITES) et les amendes liées aux
   incidents.
+
+### Référentiel réglementaire et obligations
+
+Le module `components/regulations/` expose un référentiel statique des espèces
+gérées (autorisée/interdite/soumise à autorisation), des exigences
+documentaires (certificat de cession, registre Cerfa, programme pédagogique),
+des dimensions minimales et des plages environnementales. L'API `regulations.h`
+permet de valider un profil (`regulations_validate_species`), d'évaluer la
+conformité d'un terrarium (`regulations_evaluate`) et d'obtenir les libellés
+juridiques associés. Ces règles sont appliquées par `reptile_logic` lors de
+chaque changement d'espèce, de configuration ou de document : les demandes non
+conformes sont bloquées, des incidents sont levés (`REPTILE_INCIDENT_*`) et les
+amendes calculées.
+
+Un écran LVGL dédié (« Obligations ») liste le référentiel, les terrariums en
+infraction et propose l'export d'un rapport CSV sur microSD
+(`/sdcard/reports/…`). Les utilisateurs disposent ainsi d'un rappel pédagogique
+des exigences légales françaises : arrêté du **8 octobre 2018** (conditions de
+détention d'animaux non domestiques), **Règlement (CE) n° 338/97** relatif à la
+mise en œuvre de CITES et articles **L413-2 / R413-23 du Code de
+l'environnement** pour les obligations d'autorisation et d'information du
+public.
 
 L'état complet est persisté sur microSD via `reptile_facility_save` et
 `reptile_facility_load` avec versionnement et slots multiples.
@@ -149,11 +174,13 @@ Pour valider la simulation sur un PC hôte, un binaire autonome peut être
 compilé grâce aux stubs présents dans `tests/include/` :
 
 ```sh
-gcc -DGAME_MODE_SIMULATION \
+gcc \
     tests/sim_reptile.c \
     components/reptile_logic/reptile_logic.c \
+    components/regulations/regulations.c \
+    components/config/game_mode.c \
     -Itests/include -Icomponents/reptile_logic -Icomponents/config \
-    -lm -o sim_reptile && ./sim_reptile
+    -Icomponents/regulations -lm -o sim_reptile && ./sim_reptile
 ```
 
 Le programme imprime l'évolution de la croissance, des incidents de conformité

--- a/components/regulations/CMakeLists.txt
+++ b/components/regulations/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "regulations.c"
+    INCLUDE_DIRS "." "../reptile_logic"
+)

--- a/components/regulations/regulations.c
+++ b/components/regulations/regulations.c
@@ -1,0 +1,260 @@
+#include "regulations.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "reptile_logic.h"
+
+static const regulation_rule_t s_rules[] = {
+    {
+        .species_id = REPTILE_SPECIES_GECKO,
+        .scientific_name = "Eublepharis macularius",
+        .common_name = "Gecko léopard",
+        .status = REGULATORY_STATUS_AUTHORIZED,
+        .certificate_required = true,
+        .certificate_text =
+            "Certificat de cession + preuve d'origine (Annexe B - Règlement (CE) 338/97)",
+        .register_required = true,
+        .min_length_cm = 90.f,
+        .min_width_cm = 45.f,
+        .min_height_cm = 45.f,
+        .day_temp_min = 28.f,
+        .day_temp_max = 32.f,
+        .night_temp_min = 24.f,
+        .night_temp_max = 27.f,
+        .humidity_min = 40.f,
+        .humidity_max = 60.f,
+        .uv_min = 2.f,
+        .uv_max = 3.5f,
+        .education_required = true,
+        .education_text =
+            "Affichage des conditions de détention et sensibilisation au prélèvement", 
+        .legal_reference =
+            "Arrêté du 8/10/2018 + Règlement (CE) 338/97",
+    },
+    {
+        .species_id = REPTILE_SPECIES_PYTHON,
+        .scientific_name = "Python regius",
+        .common_name = "Python royal",
+        .status = REGULATORY_STATUS_CONTROLLED,
+        .certificate_required = true,
+        .certificate_text =
+            "Certificat intra-communautaire CITES B et registre Cerfa 12446*01",
+        .register_required = true,
+        .min_length_cm = 120.f,
+        .min_width_cm = 60.f,
+        .min_height_cm = 60.f,
+        .day_temp_min = 30.f,
+        .day_temp_max = 34.f,
+        .night_temp_min = 26.f,
+        .night_temp_max = 28.f,
+        .humidity_min = 55.f,
+        .humidity_max = 75.f,
+        .uv_min = 2.5f,
+        .uv_max = 4.0f,
+        .education_required = true,
+        .education_text =
+            "Programme pédagogique sur la gestion des NAC soumis à autorisation",
+        .legal_reference =
+            "Code de l'environnement L413-2 et Arrêté du 8/10/2018",
+    },
+    {
+        .species_id = REPTILE_SPECIES_TORTOISE,
+        .scientific_name = "Testudo hermanni",
+        .common_name = "Tortue d'Hermann",
+        .status = REGULATORY_STATUS_CONTROLLED,
+        .certificate_required = true,
+        .certificate_text =
+            "Certificat intra-communautaire (Annexe A) + marquage micro-puce",
+        .register_required = true,
+        .min_length_cm = 200.f,
+        .min_width_cm = 100.f,
+        .min_height_cm = 60.f,
+        .day_temp_min = 27.f,
+        .day_temp_max = 32.f,
+        .night_temp_min = 20.f,
+        .night_temp_max = 24.f,
+        .humidity_min = 50.f,
+        .humidity_max = 70.f,
+        .uv_min = 3.f,
+        .uv_max = 4.5f,
+        .education_required = true,
+        .education_text =
+            "Panneau sur la protection de l'espèce et obligations de marquage",
+        .legal_reference =
+            "Règlement (CE) 338/97 + Arrêté du 8/10/2018",
+    },
+    {
+        .species_id = REPTILE_SPECIES_CHAMELEON,
+        .scientific_name = "Furcifer pardalis",
+        .common_name = "Caméléon panthère",
+        .status = REGULATORY_STATUS_CONTROLLED,
+        .certificate_required = true,
+        .certificate_text =
+            "Certificat de cession CITES B et registre d'entrées/sorties",
+        .register_required = true,
+        .min_length_cm = 90.f,
+        .min_width_cm = 60.f,
+        .min_height_cm = 120.f,
+        .day_temp_min = 29.f,
+        .day_temp_max = 33.f,
+        .night_temp_min = 22.f,
+        .night_temp_max = 25.f,
+        .humidity_min = 55.f,
+        .humidity_max = 85.f,
+        .uv_min = 4.f,
+        .uv_max = 5.5f,
+        .education_required = true,
+        .education_text =
+            "Sensibilisation à l'hygrométrie et à la gestion UV des caméléons",
+        .legal_reference =
+            "Arrêté du 8/10/2018 + Règlement (CE) 338/97",
+    },
+    {
+        .species_id = REPTILE_SPECIES_CUSTOM,
+        .scientific_name = "Profil personnalisé",
+        .common_name = "Espèce non listée",
+        .status = REGULATORY_STATUS_ASSESSMENT,
+        .certificate_required = true,
+        .certificate_text =
+            "Validation préalable DDPP + pièces justificatives spécifiques",
+        .register_required = true,
+        .min_length_cm = 120.f,
+        .min_width_cm = 60.f,
+        .min_height_cm = 60.f,
+        .day_temp_min = 26.f,
+        .day_temp_max = 32.f,
+        .night_temp_min = 22.f,
+        .night_temp_max = 28.f,
+        .humidity_min = 45.f,
+        .humidity_max = 70.f,
+        .uv_min = 2.5f,
+        .uv_max = 5.5f,
+        .education_required = true,
+        .education_text =
+            "Dossier pédagogique à construire selon l'espèce",
+        .legal_reference =
+            "Instruction préfectorale préalable + Code de l'environnement",
+    },
+};
+
+size_t regulations_get_rules(const regulation_rule_t **rules_out) {
+  if (rules_out) {
+    *rules_out = s_rules;
+  }
+  return sizeof(s_rules) / sizeof(s_rules[0]);
+}
+
+const regulation_rule_t *regulations_get_rule(int species_id) {
+  size_t count = sizeof(s_rules) / sizeof(s_rules[0]);
+  for (size_t i = 0; i < count; ++i) {
+    if (s_rules[i].species_id == species_id) {
+      return &s_rules[i];
+    }
+  }
+  return NULL;
+}
+
+const char *regulations_status_to_string(regulatory_status_t status) {
+  switch (status) {
+  case REGULATORY_STATUS_FORBIDDEN:
+    return "Interdite";
+  case REGULATORY_STATUS_CONTROLLED:
+    return "Soumise à autorisation";
+  case REGULATORY_STATUS_AUTHORIZED:
+    return "Autorisée";
+  case REGULATORY_STATUS_ASSESSMENT:
+  default:
+    return "Évaluation requise";
+  }
+}
+
+static void set_reason(char *reason, size_t reason_len, const char *fmt,
+                       const char *detail) {
+  if (!reason || reason_len == 0 || !fmt) {
+    return;
+  }
+  snprintf(reason, reason_len, fmt, detail ? detail : "");
+}
+
+esp_err_t regulations_validate_species(int species_id, char *reason,
+                                       size_t reason_len) {
+  const regulation_rule_t *rule = regulations_get_rule(species_id);
+  if (!rule) {
+    set_reason(reason, reason_len, "Espèce inconnue (%s)", "catalogue");
+    return ESP_ERR_NOT_FOUND;
+  }
+  switch (rule->status) {
+  case REGULATORY_STATUS_FORBIDDEN:
+    set_reason(reason, reason_len, "Espèce interdite d'introduction: %s",
+               rule->legal_reference);
+    return ESP_ERR_INVALID_STATE;
+  case REGULATORY_STATUS_ASSESSMENT:
+    set_reason(reason, reason_len,
+               "Validation administrative requise avant introduction (%s)",
+               rule->legal_reference);
+    return ESP_ERR_INVALID_STATE;
+  default:
+    break;
+  }
+  return ESP_OK;
+}
+
+static bool value_in_range(float value, float min_v, float max_v) {
+  if (max_v <= min_v) {
+    return true;
+  }
+  return value >= min_v && value <= max_v;
+}
+
+esp_err_t regulations_evaluate(const regulation_rule_t *rule,
+                               const regulations_compliance_input_t *input,
+                               regulations_compliance_report_t *report) {
+  if (!rule || !input || !report) {
+    return ESP_ERR_INVALID_ARG;
+  }
+
+  memset(report, 0, sizeof(*report));
+
+  bool allowed = rule->status != REGULATORY_STATUS_FORBIDDEN &&
+                 rule->status != REGULATORY_STATUS_ASSESSMENT;
+  report->allowed = allowed;
+
+  bool certificate_ok = true;
+  if (rule->certificate_required) {
+    certificate_ok = input->certificate_count > 0 && input->certificate_valid &&
+                     !input->certificate_expired;
+  }
+  report->certificate_ok = certificate_ok;
+
+  bool register_ok = true;
+  if (rule->register_required) {
+    register_ok = input->register_present;
+  }
+  report->register_ok = register_ok;
+
+  bool dimensions_ok = input->length_cm >= rule->min_length_cm &&
+                       input->width_cm >= rule->min_width_cm &&
+                       input->height_cm >= rule->min_height_cm;
+  report->dimensions_ok = dimensions_ok;
+
+  bool education_ok = true;
+  if (rule->education_required) {
+    education_ok = input->education_present;
+  }
+  report->education_ok = education_ok;
+
+  float temp_min = input->is_daytime ? rule->day_temp_min : rule->night_temp_min;
+  float temp_max = input->is_daytime ? rule->day_temp_max : rule->night_temp_max;
+  bool temp_ok = value_in_range(input->temperature_c, temp_min, temp_max);
+  bool humidity_ok = value_in_range(input->humidity_pct, rule->humidity_min,
+                                    rule->humidity_max);
+  bool uv_ok = value_in_range(input->uv_index, rule->uv_min, rule->uv_max);
+  report->environment_ok = temp_ok && humidity_ok && uv_ok;
+
+  report->blocking = !report->allowed || !report->dimensions_ok ||
+                     !report->certificate_ok || !report->register_ok;
+
+  return ESP_OK;
+}

--- a/components/regulations/regulations.h
+++ b/components/regulations/regulations.h
@@ -1,0 +1,82 @@
+#ifndef REGULATIONS_H
+#define REGULATIONS_H
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  REGULATORY_STATUS_FORBIDDEN = 0,
+  REGULATORY_STATUS_CONTROLLED,
+  REGULATORY_STATUS_AUTHORIZED,
+  REGULATORY_STATUS_ASSESSMENT,
+} regulatory_status_t;
+
+typedef struct {
+  int species_id;
+  const char *scientific_name;
+  const char *common_name;
+  regulatory_status_t status;
+  bool certificate_required;
+  const char *certificate_text;
+  bool register_required;
+  float min_length_cm;
+  float min_width_cm;
+  float min_height_cm;
+  float day_temp_min;
+  float day_temp_max;
+  float night_temp_min;
+  float night_temp_max;
+  float humidity_min;
+  float humidity_max;
+  float uv_min;
+  float uv_max;
+  bool education_required;
+  const char *education_text;
+  const char *legal_reference;
+} regulation_rule_t;
+
+typedef struct {
+  float length_cm;
+  float width_cm;
+  float height_cm;
+  float temperature_c;
+  float humidity_pct;
+  float uv_index;
+  bool is_daytime;
+  unsigned int certificate_count;
+  bool certificate_valid;
+  bool certificate_expired;
+  bool register_present;
+  bool education_present;
+} regulations_compliance_input_t;
+
+typedef struct {
+  bool allowed;
+  bool certificate_ok;
+  bool register_ok;
+  bool dimensions_ok;
+  bool education_ok;
+  bool environment_ok;
+  bool blocking;
+} regulations_compliance_report_t;
+
+size_t regulations_get_rules(const regulation_rule_t **rules_out);
+const regulation_rule_t *regulations_get_rule(int species_id);
+const char *regulations_status_to_string(regulatory_status_t status);
+esp_err_t regulations_validate_species(int species_id, char *reason,
+                                       size_t reason_len);
+esp_err_t regulations_evaluate(const regulation_rule_t *rule,
+                               const regulations_compliance_input_t *input,
+                               regulations_compliance_report_t *report);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* REGULATIONS_H */

--- a/components/reptile_logic/CMakeLists.txt
+++ b/components/reptile_logic/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "reptile_logic.c"
     INCLUDE_DIRS "."
-    REQUIRES nvs_flash gpio config
+    REQUIRES nvs_flash gpio config regulations
     PRIV_REQUIRES sensors sd
 )

--- a/components/reptile_logic/reptile_logic.h
+++ b/components/reptile_logic/reptile_logic.h
@@ -17,6 +17,7 @@ extern "C" {
 #define REPTILE_CONFIG_STR_LEN 32U
 #define REPTILE_CERT_AUTH_LEN 32U
 #define REPTILE_CERT_ID_LEN 24U
+#define REPTILE_COMPLIANCE_MSG_LEN 96U
 
 typedef enum {
   REPTILE_GROWTH_HATCHLING = 0,
@@ -38,6 +39,9 @@ typedef enum {
   REPTILE_INCIDENT_CERTIFICATE_MISSING,
   REPTILE_INCIDENT_CERTIFICATE_EXPIRED,
   REPTILE_INCIDENT_ENVIRONMENT_OUT_OF_RANGE,
+  REPTILE_INCIDENT_REGISTER_MISSING,
+  REPTILE_INCIDENT_DIMENSION_NON_CONFORM,
+  REPTILE_INCIDENT_EDUCATION_MISSING,
   REPTILE_INCIDENT_AUDIT_LOCK,
 } reptile_incident_t;
 
@@ -83,6 +87,12 @@ typedef struct {
   char heating[REPTILE_CONFIG_STR_LEN];
   char decor[REPTILE_CONFIG_STR_LEN];
   char uv_setup[REPTILE_CONFIG_STR_LEN];
+  float length_cm;
+  float width_cm;
+  float height_cm;
+  bool educational_panel_present;
+  bool register_completed;
+  char register_reference[REPTILE_CERT_ID_LEN];
 } reptile_terrarium_config_t;
 
 typedef struct {
@@ -144,6 +154,7 @@ typedef struct {
   int64_t revenue_cents_per_day;
 
   time_t last_update;
+  char compliance_message[REPTILE_COMPLIANCE_MSG_LEN];
 } terrarium_t;
 
 typedef struct {
@@ -205,6 +216,15 @@ esp_err_t reptile_terrarium_set_decor(terrarium_t *terrarium,
 esp_err_t reptile_terrarium_set_uv(terrarium_t *terrarium, const char *uv);
 esp_err_t reptile_terrarium_add_certificate(
     terrarium_t *terrarium, const reptile_certificate_t *certificate);
+esp_err_t reptile_terrarium_set_dimensions(terrarium_t *terrarium,
+                                           float length_cm, float width_cm,
+                                           float height_cm);
+void reptile_terrarium_set_education(terrarium_t *terrarium, bool present);
+esp_err_t reptile_terrarium_set_register(terrarium_t *terrarium,
+                                         bool recorded,
+                                         const char *reference);
+esp_err_t reptile_facility_export_regulation_report(
+    const reptile_facility_t *facility, const char *relative_path);
 
 void reptile_inventory_add_feed(reptile_facility_t *facility,
                                 uint32_t quantity);

--- a/tests/include/esp_err.h
+++ b/tests/include/esp_err.h
@@ -9,6 +9,7 @@ typedef int32_t esp_err_t;
 #define ESP_ERR_INVALID_ARG 0x102
 #define ESP_ERR_NO_MEM 0x103
 #define ESP_ERR_NOT_FOUND 0x104
+#define ESP_ERR_INVALID_STATE 0x105
 
 static inline const char *esp_err_to_name(esp_err_t err) {
   switch (err) {
@@ -22,6 +23,8 @@ static inline const char *esp_err_to_name(esp_err_t err) {
     return "ESP_ERR_NO_MEM";
   case ESP_ERR_NOT_FOUND:
     return "ESP_ERR_NOT_FOUND";
+  case ESP_ERR_INVALID_STATE:
+    return "ESP_ERR_INVALID_STATE";
   default:
     return "ESP_ERR_UNKNOWN";
   }


### PR DESCRIPTION
## Summary
- add a dedicated regulations component exposing species legality, certificate requirements, registers and environmental ranges
- integrate regulatory validation into reptile_logic with new incidents, compliance messaging, and CSV export on microSD
- extend the LVGL game UI with obligations screen, dimension selector, register toggle, and legal awareness messaging
- document the legal framework and update the host simulation test harness

## Testing
- gcc tests/sim_reptile.c components/reptile_logic/reptile_logic.c components/regulations/regulations.c components/config/game_mode.c -Itests/include -Icomponents/reptile_logic -Icomponents/config -Icomponents/regulations -lm -o sim_reptile && ./sim_reptile

------
https://chatgpt.com/codex/tasks/task_e_68c9db653a608323aa2aee7339d58486