### PR TITLE
Fix regulations component dependencies

### DIFF
--- a/components/regulations/CMakeLists.txt
+++ b/components/regulations/CMakeLists.txt
@@ -1,4 +1,6 @@
 idf_component_register(
     SRCS "regulations.c"
-    INCLUDE_DIRS "." "../reptile_logic"
+    INCLUDE_DIRS "."
+    PRIV_INCLUDE_DIRS "../reptile_logic"
+    REQUIRES config
 )


### PR DESCRIPTION
## Summary
- add the config component requirement so regulations resolves `game_mode.h`
- scope the manual `reptile_logic` include directory to this component only

## Testing
- `idf.py build` *(fails: command not found in the provided container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e5b7740883239a184bc53fdd5d15