### PR TITLE
Fix logging format specifiers for 32-bit counters

### DIFF
--- a/components/logging/logging.c
+++ b/components/logging/logging.c
@@ -35,14 +35,14 @@ static void logging_timer_cb(lv_timer_t *t)
     }
     time_t now = time(NULL);
     fprintf(f,
-            "%ld,%s,%lld,%u,%u,%u,%u,%lld,%lld,%lld\n",
+            "%ld,%s,%lld,%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%" PRIu32 ",%lld,%lld,%lld\n",
             (long)now,
             facility->slot,
             (long long)facility->economy.cash_cents,
-            metrics.occupied,
-            facility->alerts_active,
-            facility->pathology_active,
-            facility->compliance_alerts,
+            (uint32_t)metrics.occupied,
+            (uint32_t)facility->alerts_active,
+            (uint32_t)facility->pathology_active,
+            (uint32_t)facility->compliance_alerts,
             (long long)facility->economy.daily_income_cents,
             (long long)facility->economy.daily_expenses_cents,
             (long long)facility->economy.fines_cents);


### PR DESCRIPTION
## Summary
- use PRIu32-aware format strings for facility occupancy and alert counters to avoid format warnings

## Testing
- ❌ `idf.py build` *(command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e72af594832395b8c241bae7ad89