### PR TITLE
Declare Montserrat 20 font in reptile game

### DIFF
--- a/main/reptile_game.c
+++ b/main/reptile_game.c
@@ -17,6 +17,7 @@
 #include <time.h>
 
 LV_FONT_DECLARE(lv_font_montserrat_24);
+LV_FONT_DECLARE(lv_font_montserrat_20);
 
 #define TERRARIUM_GRID_SIZE 5U
 #define FACILITY_UPDATE_PERIOD_MS 1000U


### PR DESCRIPTION
## Summary
- declare the LVGL Montserrat 20 font alongside the existing 24pt declaration used by the reptile game UI

## Testing
- idf.py build *(fails in container: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f9f2d54c83238773a9a31387c488