### PR TITLE
Fix LovyanGFX ESP32-S3 patch include paths

### DIFF
--- a/components/lovyangfx_patch/CMakeLists.txt
+++ b/components/lovyangfx_patch/CMakeLists.txt
@@ -9,11 +9,13 @@ idf_component_register(
 )
 
 idf_component_get_property(lovyangfx_dir lovyangfx COMPONENT_DIR)
-idf_component_get_property(lovyangfx_target lovyangfx COMPONENT_LIB)
 
-if(lovyangfx_dir AND EXISTS "${lovyangfx_dir}/src/lgfx/v1/platforms/esp32s3/Bus_RGB.cpp")
-    set_source_files_properties(
-        "${lovyangfx_dir}/src/lgfx/v1/platforms/esp32s3/Bus_RGB.cpp"
-        PROPERTIES HEADER_FILE_ONLY TRUE
-    )
+if(lovyangfx_dir)
+    target_include_directories(${COMPONENT_LIB} PRIVATE "${lovyangfx_dir}/src")
+    if(EXISTS "${lovyangfx_dir}/src/lgfx/v1/platforms/esp32s3/Bus_RGB.cpp")
+        set_source_files_properties(
+            "${lovyangfx_dir}/src/lgfx/v1/platforms/esp32s3/Bus_RGB.cpp"
+            PROPERTIES HEADER_FILE_ONLY TRUE
+        )
+    endif()
 endif()

--- a/components/lovyangfx_patch/src/lgfx/v1/platforms/esp32s3/Bus_RGB.hpp
+++ b/components/lovyangfx_patch/src/lgfx/v1/platforms/esp32s3/Bus_RGB.hpp
@@ -28,9 +28,9 @@ Contributors:
 #include <esp_private/gdma.h>
 #include <hal/dma_types.h>
 
-#include "../../Bus.hpp"
-#include "../../panel/Panel_FrameBufferBase.hpp"
-#include "../common.hpp"
+#include "lgfx/v1/Bus.hpp"
+#include "lgfx/v1/panel/Panel_FrameBufferBase.hpp"
+#include "lgfx/v1/platforms/common.hpp"
 
 struct lcd_cam_dev_t;
 struct esp_rgb_panel_t;


### PR DESCRIPTION
## Summary
- point the lovyangfx_patch component at the upstream LovyanGFX include directory so the patched Bus_RGB build sees the rest of the lgfx headers
- replace the local relative includes in Bus_RGB.hpp with absolute lgfx paths that remain valid when the file is vendored into the patch component

## Testing
- idf.py build *(fails: idf.py not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca72901f9083239f75e3bbe3b80ad9