### PR TITLE
Stop auto-populating facility terrariums

### DIFF
--- a/components/reptile_logic/reptile_logic.c
+++ b/components/reptile_logic/reptile_logic.c
@@ -261,7 +261,7 @@ static void terrarium_reset(terrarium_t *terrarium) {
   copy_string(terrarium->config.uv_setup, sizeof(terrarium->config.uv_setup),
               "UVB T5 5%");
   terrarium_set_compliance_message(terrarium,
-                                   "Aucune espèce attribuée");
+                                   "Terrarium disponible (aucune espèce attribuée)");
 }
 
 static void facility_reset(reptile_facility_t *facility) {
@@ -291,30 +291,6 @@ static void facility_reset(reptile_facility_t *facility) {
   facility->mature_count = 0;
   facility->last_persist_time = 0;
   facility->average_growth = 0.0f;
-
-  const species_profile_t *gecko = reptile_species_get(REPTILE_SPECIES_GECKO);
-  const species_profile_t *python = reptile_species_get(REPTILE_SPECIES_PYTHON);
-  const species_profile_t *tortoise =
-      reptile_species_get(REPTILE_SPECIES_TORTOISE);
-  const species_profile_t *chameleon =
-      reptile_species_get(REPTILE_SPECIES_CHAMELEON);
-
-  if (gecko) {
-    reptile_terrarium_set_species(&facility->terrariums[0], gecko,
-                                  "Gecko 01");
-  }
-  if (python) {
-    reptile_terrarium_set_species(&facility->terrariums[1], python,
-                                  "Python 01");
-  }
-  if (tortoise) {
-    reptile_terrarium_set_species(&facility->terrariums[2], tortoise,
-                                  "Tortue 01");
-  }
-  if (chameleon) {
-    reptile_terrarium_set_species(&facility->terrariums[3], chameleon,
-                                  "Caméléon 01");
-  }
 }
 
 static const char *mode_dir(game_mode_t mode) {

--- a/main/reptile_game.c
+++ b/main/reptile_game.c
@@ -1020,9 +1020,52 @@ static void update_detail_screen(void) {
       reptile_facility_get_terrarium_const(&g_facility,
                                            (uint8_t)selected_terrarium);
   if (!terrarium || !terrarium->occupied) {
-    lv_label_set_text(detail_title, "Terrarium libre");
+    lv_label_set_text(detail_title, "Terrarium disponible");
     lv_label_set_text(detail_status_label,
-                      "Sélectionner un terrarium occupé pour éditer");
+                      "Attribuer une espèce pour configurer ce terrarium");
+    if (detail_status_icon) {
+      lv_img_set_src(detail_status_icon, &gImage_terrarium_ok);
+    }
+    if (detail_env_table) {
+      static const char *kLabels[12] = {
+          "Température",    "Humidité",   "Index UV",      "Satiété",
+          "Hydratation",    "Croissance", "Poids",        "Stade",
+          "Pathologie",     "Incident",   "Dimensions",    "Obligations",
+      };
+      for (uint32_t row = 0; row < 12U; ++row) {
+        lv_table_set_cell_value(detail_env_table, row, 0, kLabels[row]);
+        lv_table_set_cell_value(detail_env_table, row, 1, "-");
+      }
+    }
+    if (detail_cert_table) {
+      lv_table_set_row_count(detail_cert_table, 2);
+      lv_table_set_cell_value(detail_cert_table, 0, 0, "Identifiant");
+      lv_table_set_cell_value(detail_cert_table, 0, 1, "Échéance");
+      lv_table_set_cell_value(detail_cert_table, 1, 0, "-");
+      lv_table_set_cell_value(detail_cert_table, 1, 1,
+                              "Aucun certificat enregistré");
+    }
+    if (detail_compliance_label) {
+      lv_label_set_text(detail_compliance_label,
+                        "Aucune conformité requise sans espèce");
+    }
+    dropdown_select_none(dropdown_substrate);
+    dropdown_select_none(dropdown_heating);
+    dropdown_select_none(dropdown_decor);
+    dropdown_select_none(dropdown_uv);
+    dropdown_select_none(dropdown_size);
+    if (education_switch_detail) {
+      lv_obj_clear_state(education_switch_detail, LV_STATE_CHECKED);
+    }
+    if (detail_register_label) {
+      lv_label_set_text(detail_register_label, "Registre non renseigné");
+    }
+    if (register_button) {
+      lv_obj_t *label = lv_obj_get_child(register_button, 0);
+      if (label) {
+        lv_label_set_text(label, "Consigner la cession");
+      }
+    }
     return;
   }
   const species_profile_t *profile = &terrarium->species;

--- a/tests/sim_reptile.c
+++ b/tests/sim_reptile.c
@@ -39,6 +39,33 @@ int main(void) {
   printf("Initial occupied=%u free=%u cash=%.2f€\n", metrics.occupied,
          metrics.free_slots, facility.economy.cash_cents / 100.0);
 
+  terrarium_t *t0_setup = reptile_facility_get_terrarium(&facility, 0);
+  terrarium_t *t1_setup = reptile_facility_get_terrarium(&facility, 1);
+  terrarium_t *t2_setup = reptile_facility_get_terrarium(&facility, 2);
+  terrarium_t *t3_setup = reptile_facility_get_terrarium(&facility, 3);
+  const species_profile_t *gecko = reptile_species_get(REPTILE_SPECIES_GECKO);
+  const species_profile_t *python = reptile_species_get(REPTILE_SPECIES_PYTHON);
+  const species_profile_t *tortoise =
+      reptile_species_get(REPTILE_SPECIES_TORTOISE);
+  const species_profile_t *chameleon =
+      reptile_species_get(REPTILE_SPECIES_CHAMELEON);
+  if (t0_setup && gecko) {
+    reptile_terrarium_set_species(t0_setup, gecko, "Gecko 01");
+  }
+  if (t1_setup && python) {
+    reptile_terrarium_set_species(t1_setup, python, "Python 01");
+  }
+  if (t2_setup && tortoise) {
+    reptile_terrarium_set_species(t2_setup, tortoise, "Tortue 01");
+  }
+  if (t3_setup && chameleon) {
+    reptile_terrarium_set_species(t3_setup, chameleon, "Caméléon 01");
+  }
+
+  reptile_facility_compute_metrics(&facility, &metrics);
+  printf("Après attribution manuelle occupied=%u free=%u\n", metrics.occupied,
+         metrics.free_slots);
+
   esp_err_t custom_err = reptile_terrarium_set_species(
       reptile_facility_get_terrarium(&facility, 4),
       reptile_species_get(REPTILE_SPECIES_CUSTOM), "Custom");


### PR DESCRIPTION
## Summary
- prevent facility_reset() from auto-assigning species and keep terrariums marked available by default
- refresh the LVGL detail screen to display "Terrarium disponible" and clear widgets when no species is selected
- update the host simulation harness to assign species explicitly before running growth/compliance scenarios

## Testing
- gcc \
    tests/sim_reptile.c \
    components/reptile_logic/reptile_logic.c \
    components/regulations/regulations.c \
    components/config/game_mode.c \
    -Itests/include -Icomponents/reptile_logic -Icomponents/config \
    -Icomponents/regulations -lm -o sim_reptile && ./sim_reptile

------
https://chatgpt.com/codex/tasks/task_e_68caf9ec3e208323bcf1ab2d071bceb3