### PR TITLE
Add weekly subsidy credit and expose in economy UI

### DIFF
--- a/components/reptile_logic/reptile_logic.h
+++ b/components/reptile_logic/reptile_logic.h
@@ -110,6 +110,7 @@ typedef struct {
   int64_t daily_expenses_cents;
   int64_t fines_cents;
   uint32_t days_elapsed;
+  int64_t weekly_subsidy_cents;
 } reptile_economy_t;
 
 typedef struct {

--- a/main/reptile_game.c
+++ b/main/reptile_game.c
@@ -1411,8 +1411,10 @@ static void update_economy_screen(void) {
   lv_label_set_text_fmt(
       economy_summary_label,
       "Jour %" PRIu32
-      " | Recettes: %.2f € | Dépenses: %.2f € | Amendes cumulées: %.2f €",
+      " | Revenu hebdo: %.2f € | Revenu d'exploitation: %.2f € | Dépenses: %.2f € |"
+      " Amendes cumulées: %.2f €",
       g_facility.economy.days_elapsed,
+      g_facility.economy.weekly_subsidy_cents / 100.0,
       g_facility.economy.daily_income_cents / 100.0,
       g_facility.economy.daily_expenses_cents / 100.0,
       g_facility.economy.fines_cents / 100.0);


### PR DESCRIPTION
## Summary
- add a configurable weekly subsidy default for the facility economy and persist it with backward-compatible loading
- trigger the weekly subsidy credit during the facility tick while keeping daily operating income untouched
- surface the weekly subsidy separately from daily operating revenue on the economy screen

## Testing
- gcc tests/sim_reptile.c components/reptile_logic/reptile_logic.c components/regulations/regulations.c components/config/game_mode.c -Itests/include -Icomponents/reptile_logic -Icomponents/config -Icomponents/regulations -lm -o sim_reptile && ./sim_reptile

------
https://chatgpt.com/codex/tasks/task_e_68cafee9110c8323b464460734eb3509