### PR TITLE
Add UV lux sensing and propagate to control and UI

### DIFF
--- a/components/env_control/env_control.h
+++ b/components/env_control/env_control.h
@@ -24,6 +24,7 @@ typedef enum {
     REPTILE_ENV_ALARM_TEMP_HIGH      = (1u << 2),
     REPTILE_ENV_ALARM_HUM_LOW        = (1u << 3),
     REPTILE_ENV_ALARM_HUM_HIGH       = (1u << 4),
+    REPTILE_ENV_ALARM_LIGHT_LOW      = (1u << 5),
 } reptile_env_alarm_flags_t;
 
 /** Simple representation of a wall-clock time of day. */
@@ -88,18 +89,23 @@ typedef struct {
     time_t timestamp;           /*!< Wall-clock timestamp */
     float temperature_c;        /*!< Measured temperature */
     float humidity_pct;         /*!< Measured humidity */
+    float light_lux;            /*!< Measured illuminance (lux) */
     float target_temperature_c; /*!< Active target temperature */
     float target_humidity_pct;  /*!< Active target humidity */
+    float target_light_lux;     /*!< Expected minimum illuminance when UV is on */
 } reptile_env_history_entry_t;
 
 /** Runtime state of a single terrarium. */
 typedef struct {
     float temperature_c;        /*!< Last measured temperature */
     float humidity_pct;         /*!< Last measured humidity */
+    float light_lux;            /*!< Last measured illuminance in lux */
     float target_temperature_c; /*!< Target temperature according to schedule */
     float target_humidity_pct;  /*!< Target humidity according to schedule */
+    float target_light_lux;     /*!< Expected minimum illuminance when UV should be on */
     bool  temperature_valid;    /*!< Measurement validity */
     bool  humidity_valid;       /*!< Measurement validity */
+    bool  light_valid;          /*!< Measurement validity */
     bool  heating;              /*!< Heating actuator active */
     bool  pumping;              /*!< Humidification actuator active */
     bool  uv_light;             /*!< UV lighting active */

--- a/components/logging/logging_real.c
+++ b/components/logging/logging_real.c
@@ -69,7 +69,7 @@ static esp_err_t ensure_directory(const char *path)
 
 static void write_header(FILE *f)
 {
-    fputs("timestamp,temp_c,humidity_pct,target_temp_c,target_humidity_pct,heating,pumping,uv,manual_heat,manual_pump,manual_uv,energy_heat_wh,energy_pump_wh,energy_uv_wh,total_energy_wh,alarm_flags\n",
+    fputs("timestamp,temp_c,humidity_pct,light_lux,target_temp_c,target_humidity_pct,target_light_lux,heating,pumping,uv,manual_heat,manual_pump,manual_uv,energy_heat_wh,energy_pump_wh,energy_uv_wh,total_energy_wh,alarm_flags\n",
           f);
 }
 
@@ -126,13 +126,15 @@ void logging_real_append(size_t terrarium_index, const reptile_env_terrarium_sta
     time_t now = time(NULL);
     float total = state->energy_heat_Wh + state->energy_pump_Wh + state->energy_uv_Wh;
     fprintf(f,
-            "%ld,%.3f,%.3f,%.3f,%.3f,%" PRIu8 ",%" PRIu8 ",%" PRIu8 ",%" PRIu8 ",%" PRIu8 ",%" PRIu8
+            "%ld,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%" PRIu8 ",%" PRIu8 ",%" PRIu8 ",%" PRIu8 ",%" PRIu8 ",%" PRIu8
             ",%.3f,%.3f,%.3f,%.3f,%" PRIu32 "\n",
             (long)now,
             state->temperature_c,
             state->humidity_pct,
+            state->light_lux,
             state->target_temperature_c,
             state->target_humidity_pct,
+            state->target_light_lux,
             (uint8_t)state->heating,
             (uint8_t)state->pumping,
             (uint8_t)state->uv_light,

--- a/components/sensors/sensors.c
+++ b/components/sensors/sensors.c
@@ -42,6 +42,15 @@ float sensors_read_humidity(void)
     return NAN;
 }
 
+float sensors_read_lux(void)
+{
+    sensors_select_driver();
+    if (s_driver && s_driver->read_lux) {
+        return s_driver->read_lux();
+    }
+    return NAN;
+}
+
 float sensors_read_temperature_channel(size_t channel)
 {
     sensors_select_driver();
@@ -68,6 +77,21 @@ float sensors_read_humidity_channel(size_t channel)
     }
     if (channel == 0 && s_driver->read_humidity) {
         return s_driver->read_humidity();
+    }
+    return NAN;
+}
+
+float sensors_read_lux_channel(size_t channel)
+{
+    sensors_select_driver();
+    if (!s_driver) {
+        return NAN;
+    }
+    if (s_driver->read_lux_channel) {
+        return s_driver->read_lux_channel(channel);
+    }
+    if (channel == 0 && s_driver->read_lux) {
+        return s_driver->read_lux();
     }
     return NAN;
 }

--- a/components/sensors/sensors.h
+++ b/components/sensors/sensors.h
@@ -12,17 +12,21 @@ typedef struct {
     esp_err_t (*init)(void);
     float (*read_temperature)(void);
     float (*read_humidity)(void);
+    float (*read_lux)(void);
     void (*deinit)(void);
     size_t (*get_channel_count)(void);
     float (*read_temperature_channel)(size_t channel);
     float (*read_humidity_channel)(size_t channel);
+    float (*read_lux_channel)(size_t channel);
 } sensor_driver_t;
 
 esp_err_t sensors_init(void);
 float sensors_read_temperature(void);
 float sensors_read_humidity(void);
+float sensors_read_lux(void);
 float sensors_read_temperature_channel(size_t channel);
 float sensors_read_humidity_channel(size_t channel);
+float sensors_read_lux_channel(size_t channel);
 size_t sensors_get_channel_count(void);
 void sensors_deinit(void);
 

--- a/components/sensors/sensors_sim.c
+++ b/components/sensors/sensors_sim.c
@@ -4,6 +4,7 @@
 
 static float s_temp = NAN;
 static float s_hum = NAN;
+static float s_lux = NAN;
 
 static esp_err_t sensors_sim_init(void)
 {
@@ -28,10 +29,20 @@ static float sensors_sim_read_humidity(void)
     return 40.0f + (float)(randv % 200) / 10.0f;
 }
 
+static float sensors_sim_read_lux(void)
+{
+    if (!isnan(s_lux)) {
+        return s_lux;
+    }
+    uint32_t randv = esp_random();
+    return 120.0f + (float)(randv % 800) / 4.0f; // 120 to ~320 lux
+}
+
 static void sensors_sim_deinit(void)
 {
     s_temp = NAN;
     s_hum = NAN;
+    s_lux = NAN;
 }
 
 static size_t sensors_sim_channel_count(void)
@@ -51,6 +62,12 @@ static float sensors_sim_read_humidity_channel(size_t channel)
     return sensors_sim_read_humidity();
 }
 
+static float sensors_sim_read_lux_channel(size_t channel)
+{
+    (void)channel;
+    return sensors_sim_read_lux();
+}
+
 void sensors_sim_set_temperature(float temp)
 {
     s_temp = temp;
@@ -61,13 +78,20 @@ void sensors_sim_set_humidity(float hum)
     s_hum = hum;
 }
 
+void sensors_sim_set_lux(float lux)
+{
+    s_lux = lux;
+}
+
 const sensor_driver_t sensors_sim_driver = {
     .init = sensors_sim_init,
     .read_temperature = sensors_sim_read_temperature,
     .read_humidity = sensors_sim_read_humidity,
+    .read_lux = sensors_sim_read_lux,
     .deinit = sensors_sim_deinit,
     .get_channel_count = sensors_sim_channel_count,
     .read_temperature_channel = sensors_sim_read_temperature_channel,
     .read_humidity_channel = sensors_sim_read_humidity_channel,
+    .read_lux_channel = sensors_sim_read_lux_channel,
 };
 

--- a/components/sim_api/sim_api.h
+++ b/components/sim_api/sim_api.h
@@ -6,6 +6,7 @@
 
 void sensors_sim_set_temperature(float temp);
 void sensors_sim_set_humidity(float hum);
+void sensors_sim_set_lux(float lux);
 
 bool gpio_sim_get_heater_state(void);
 bool gpio_sim_get_pump_state(void);

--- a/main/reptile_real.c
+++ b/main/reptile_real.c
@@ -214,6 +214,9 @@ static void describe_alarms(uint32_t flags, char *buffer, size_t len)
     if (flags & REPTILE_ENV_ALARM_HUM_HIGH) {
         strncat(buffer, "Hum haute ", len - strlen(buffer) - 1);
     }
+    if (flags & REPTILE_ENV_ALARM_LIGHT_LOW) {
+        strncat(buffer, "Lum basse ", len - strlen(buffer) - 1);
+    }
 }
 
 static void update_chart(terrarium_ui_t *ui, size_t index)
@@ -292,6 +295,8 @@ static void update_terrarium_ui(terrarium_ui_t *ui, const reptile_env_terrarium_
 
     char temp_str[16];
     char hum_str[16];
+    char lux_str[16];
+    char target_lux_str[16];
     if (state->temperature_valid && isfinite(state->temperature_c)) {
         snprintf(temp_str, sizeof(temp_str), "%.1f", state->temperature_c);
     } else {
@@ -302,13 +307,25 @@ static void update_terrarium_ui(terrarium_ui_t *ui, const reptile_env_terrarium_
     } else {
         snprintf(hum_str, sizeof(hum_str), "N/A");
     }
+    if (state->light_valid && isfinite(state->light_lux)) {
+        snprintf(lux_str, sizeof(lux_str), "%.1f", state->light_lux);
+    } else {
+        snprintf(lux_str, sizeof(lux_str), "N/A");
+    }
+    if (state->target_light_lux > 0.0f) {
+        snprintf(target_lux_str, sizeof(target_lux_str), "%.0f", state->target_light_lux);
+    } else {
+        snprintf(target_lux_str, sizeof(target_lux_str), "OFF");
+    }
 
     lv_label_set_text_fmt(ui->status_label,
-                          "Temp %s/%.1f°C  Hum %s/%.1f%%\nChauffage %s  Pompe %s",
+                          "Temp %s/%.1f°C  Hum %s/%.1f%%  Lum %s/%s lx\nChauffage %s  Pompe %s",
                           temp_str,
                           state->target_temperature_c,
                           hum_str,
                           state->target_humidity_pct,
+                          lux_str,
+                          target_lux_str,
                           state->heating ? "ON" : "OFF",
                           state->pumping ? "ON" : "OFF");
 


### PR DESCRIPTION
## Summary
- extend the generic sensor driver API with lux accessors and wire them to the real BH1750 reader plus simulated values
- propagate illuminance through the environment controller (state, history, alarms) and persist it in the real-mode CSV logger
- expose the live lux measurement and thresholds inside the real-time LVGL dashboard

## Testing
- cmake -S . -B build *(fails: ESP-IDF project.cmake not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0262c5d8832381f609b81234bb2f