### PR TITLE
Switch SD driver to SDSPI host

### DIFF
--- a/components/sd/sd.c
+++ b/components/sd/sd.c
@@ -12,10 +12,16 @@
  *
  ******************************************************************************/
 
+#include <stdbool.h>
+
+#include "esp_log.h"
 #include "sd.h"  // Include header file for SD card functions
+#include "driver/spi_common.h"
 
 // Global variable for SD card structure
 static sdmmc_card_t *card;
+static sdspi_dev_handle_t sdspi_device = -1;
+static bool spi_bus_initialized = false;
 
 // Define the mount point for the SD card
 const char mount_point[] = MOUNT_POINT;
@@ -23,7 +29,7 @@ const char mount_point[] = MOUNT_POINT;
 /**
  * @brief Initialize the SD card and mount the filesystem.
  *
- * This function configures the SDMMC peripheral, sets up the host and slot,
+ * This function configures the SDSPI host, sets up the SPI bus and device,
  * and mounts the FAT filesystem from the SD card. The mounting is attempted
  * multiple times, and each attempt is logged for diagnostic purposes.
  *
@@ -31,42 +37,61 @@ const char mount_point[] = MOUNT_POINT;
  * @retval ESP_FAIL if an error occurs during the process after all attempts.
  */
 esp_err_t sd_mmc_init() {
-    esp_err_t ret;
+    if (card != NULL) {
+        return ESP_OK;
+    }
+
+    sdspi_device = -1;
+    esp_err_t ret = ESP_FAIL;
     const int max_attempts = 3;
 
-    // Configuration for mounting the FAT filesystem
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-        .format_if_mount_failed = EXAMPLE_FORMAT_IF_MOUNT_FAILED, // Format if mount fails
-        .max_files = 5,                  // Max number of open files
-        .allocation_unit_size = 16 * 1024 // Allocation unit size
+        .format_if_mount_failed = EXAMPLE_FORMAT_IF_MOUNT_FAILED,
+        .max_files = 5,
+        .allocation_unit_size = 16 * 1024,
+        .disk_status_check_enable = false,
+        .use_one_fat = false,
     };
 
-    // Attempt to mount the filesystem multiple times
+    spi_bus_config_t bus_config = {
+        .mosi_io_num = SD_SPI_MOSI,
+        .miso_io_num = SD_SPI_MISO,
+        .sclk_io_num = SD_SPI_CLK,
+        .quadwp_io_num = GPIO_NUM_NC,
+        .quadhd_io_num = GPIO_NUM_NC,
+        .data4_io_num = GPIO_NUM_NC,
+        .data5_io_num = GPIO_NUM_NC,
+        .data6_io_num = GPIO_NUM_NC,
+        .data7_io_num = GPIO_NUM_NC,
+        .max_transfer_sz = 16 * 1024,
+    };
+
+    if (!spi_bus_initialized) {
+        esp_err_t bus_ret = spi_bus_initialize(SD_SPI_HOST, &bus_config, SDSPI_DEFAULT_DMA);
+        if (bus_ret == ESP_OK || bus_ret == ESP_ERR_INVALID_STATE) {
+            spi_bus_initialized = true;
+        } else {
+            ESP_LOGE(SD_TAG, "Failed to initialize SPI bus for SD card (%s)", esp_err_to_name(bus_ret));
+            return bus_ret;
+        }
+    }
+
+    sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+    host.slot = SD_SPI_HOST;
+
+    sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+    slot_config.host_id = SD_SPI_HOST;
+    slot_config.gpio_cs = SD_SPI_CS;
+    slot_config.gpio_cd = SDSPI_SLOT_NO_CD;
+    slot_config.gpio_wp = SDSPI_SLOT_NO_WP;
+    slot_config.gpio_int = SDSPI_SLOT_NO_INT;
+
     for (int attempt = 1; attempt <= max_attempts; ++attempt) {
-        ESP_LOGI(SD_TAG, "Initializing SD card (attempt %d/%d)", attempt, max_attempts);
+        ESP_LOGI(SD_TAG, "Initializing SD card over SPI (attempt %d/%d)", attempt, max_attempts);
 
-        // Use the SDMMC peripheral for SD card communication
-        ESP_LOGI(SD_TAG, "Using SDMMC peripheral");
-
-        // Host configuration with default settings for standard-speed operation
-        sdmmc_host_t host = SDMMC_HOST_DEFAULT();
-        host.max_freq_khz = SDMMC_FREQ_PROBING;   // Start at low freq for marginal cards; increase after successful mount
-
-        // Slot configuration for SDMMC
-        sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
-        slot_config.width = 1;
-        slot_config.clk   = EXAMPLE_PIN_CLK;
-        slot_config.cmd   = EXAMPLE_PIN_CMD;
-        slot_config.d0    = EXAMPLE_PIN_D0;
-        // Enable internal pull-ups on the GPIOs
-        slot_config.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
-
-        ESP_LOGI(SD_TAG, "Mounting filesystem");
-
-        // Mount the filesystem and initialize the SD card
-        ret = esp_vfs_fat_sdmmc_mount(mount_point, &host, &slot_config, &mount_config, &card);
-
+        ret = esp_vfs_fat_sdspi_mount(mount_point, &host, &slot_config, &mount_config, &card);
         if (ret == ESP_OK) {
+            sdspi_device = card->host.slot;
             ESP_LOGI(SD_TAG, "Filesystem mounted on attempt %d", attempt);
             return ESP_OK;
         }
@@ -74,26 +99,13 @@ esp_err_t sd_mmc_init() {
         if (ret == ESP_FAIL) {
             ESP_LOGE(SD_TAG, "Failed to mount filesystem on attempt %d. Format the card if mount fails.", attempt);
         } else {
-            ESP_LOGE(SD_TAG, "Failed to initialize the card on attempt %d (%s). Check pull-up resistors on the card lines.",
+            ESP_LOGE(SD_TAG, "Failed to initialize the card on attempt %d (%s)",
                      attempt, esp_err_to_name(ret));
-        }
-
-        if (card) {
-            esp_vfs_fat_sdcard_unmount(mount_point, card);
-            card = NULL;
-        } else {
-            sdmmc_host_deinit();
         }
     }
 
     ESP_LOGE(SD_TAG, "SD card initialization failed after %d attempts", max_attempts);
-    if (card) {
-        esp_vfs_fat_sdcard_unmount(mount_point, card);
-        card = NULL;
-    } else {
-        sdmmc_host_deinit();
-    }
-    return ESP_FAIL;
+    return ret;
 }
 
 /**
@@ -103,7 +115,7 @@ esp_err_t sd_mmc_init() {
  * about the SD card to the standard output.
  */
 esp_err_t sd_card_print_info() {
-    if (card == NULL) {
+    if (card == NULL || sdspi_device < 0) {
         return ESP_ERR_INVALID_STATE;
     }
     sdmmc_card_print_info(stdout, card);
@@ -123,8 +135,28 @@ esp_err_t sd_mmc_unmount() {
     if (card == NULL) {
         return ESP_ERR_INVALID_STATE;
     }
+
+    sdspi_dev_handle_t handle = sdspi_device;
     esp_err_t ret = esp_vfs_fat_sdcard_unmount(mount_point, card);
     card = NULL;
+    sdspi_device = -1;
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(SD_TAG, "Failed to unmount SD card: %s", esp_err_to_name(ret));
+        if (handle >= 0) {
+            // Best-effort cleanup when the high-level unmount fails.
+            (void)sdspi_host_remove_device(handle);
+        }
+    }
+
+    if (spi_bus_initialized) {
+        esp_err_t bus_ret = spi_bus_free(SD_SPI_HOST);
+        if (bus_ret != ESP_OK && bus_ret != ESP_ERR_INVALID_STATE) {
+            ESP_LOGW(SD_TAG, "Failed to free SPI bus: %s", esp_err_to_name(bus_ret));
+        }
+        spi_bus_initialized = false;
+    }
+
     return ret;
 }
 
@@ -138,6 +170,9 @@ esp_err_t sd_mmc_unmount() {
  * @retval ESP_FAIL if an error occurs while fetching capacity information.
  */
 esp_err_t read_sd_capacity(size_t *total_capacity, size_t *available_capacity) {
+    if (card == NULL || sdspi_device < 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
     FATFS *fs;
     uint32_t free_clusters;
 

--- a/components/sd/sd.h
+++ b/components/sd/sd.h
@@ -21,7 +21,8 @@
 #include <sys/stat.h>        // For file system metadata
 #include "esp_vfs_fat.h"     // FAT filesystem and VFS integration
 #include "sdmmc_cmd.h"       // SD card commands
-#include "driver/sdmmc_host.h" // SDMMC host driver
+#include "driver/gpio.h"     // GPIO numbering for SPI pins
+#include "driver/sdspi_host.h" // SDSPI host driver
 
 #include "io_extension.h"          // IO EXTENSION I2C CAN control header (optional inclusion)
 
@@ -30,9 +31,12 @@
 // Define constants for SD card configuration
 #define MOUNT_POINT "/sdcard"                // Mount point for SD card
 #define EXAMPLE_FORMAT_IF_MOUNT_FAILED false // Format SD card if mounting fails
-#define EXAMPLE_PIN_CLK GPIO_NUM_12          // GPIO pin for SD card clock
-#define EXAMPLE_PIN_CMD GPIO_NUM_11          // GPIO pin for SD card command line
-#define EXAMPLE_PIN_D0  GPIO_NUM_13          // GPIO pin for SD card data line (D0)
+
+#define SD_SPI_HOST SDSPI_DEFAULT_HOST       // SPI host used for the TF slot
+#define SD_SPI_MOSI GPIO_NUM_11              // MOSI routed to the TF socket
+#define SD_SPI_MISO GPIO_NUM_13              // MISO routed to the TF socket
+#define SD_SPI_CLK  GPIO_NUM_12              // SPI clock routed to the TF socket
+#define SD_SPI_CS   GPIO_NUM_10              // Chip-select for the TF socket
 
 // Function declarations
 

--- a/main/main.c
+++ b/main/main.c
@@ -209,7 +209,7 @@ static void wait_for_sd_card(void) {
       esp_task_wdt_reset();
     }
     err = sd_mmc_init();
-    if (err == ESP_OK || err == ESP_ERR_INVALID_STATE) {
+    if (err == ESP_OK) {
       hide_error_screen();
       if (wdt_registered) {
         esp_err_t del_ret = esp_task_wdt_delete(NULL);


### PR DESCRIPTION
## Summary
- migrate the SD stack to the SDSPI host with explicit SPI bus setup for the Waveshare ESP32-S3 Touch LCD 7B
- expose board-specific MOSI/MISO/CLK/CS definitions in the SD component header
- harden unmount and capacity helpers to track the SDSPI device handle and free the SPI bus cleanly
- streamline wait_for_sd_card() now that sd_mmc_init() reports success through ESP_OK only

## Testing
- not run (ESP-IDF toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb1b4460b483239fae766cd6d9d18b