### PR TITLE
Refactor SD SPI CS handling via IO extension

### DIFF
--- a/components/sd/sd.h
+++ b/components/sd/sd.h
@@ -36,7 +36,7 @@
 #define SD_SPI_MOSI GPIO_NUM_11              // MOSI routed to the TF socket
 #define SD_SPI_MISO GPIO_NUM_13              // MISO routed to the TF socket
 #define SD_SPI_CLK  GPIO_NUM_12              // SPI clock routed to the TF socket
-#define SD_SPI_CS   GPIO_NUM_10              // Chip-select for the TF socket
+#define SD_SPI_CS   IO_EXTENSION_IO_4        // Chip-select routed through the IO extension
 
 // Function declarations
 


### PR DESCRIPTION
## Summary
- route SD card chip-select through the IO extension and control it via new SPI transaction callbacks
- replace esp_vfs_fat_sdspi_mount usage with explicit SDSPI device setup and FAT filesystem management to integrate the IO extension CS handling
- ensure unmounting releases the IO expander line, detaches the SDSPI device, and tears down the filesystem context cleanly

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb260ca1a0832381ee9c6d1c4d505f