### PR TITLE
Fix IO extension initialization to prepare I2C bus

### DIFF
--- a/components/i2c/i2c.c
+++ b/components/i2c/i2c.c
@@ -86,6 +86,15 @@ esp_err_t DEV_I2C_Probe(uint8_t addr)
  */
 esp_err_t DEV_I2C_Set_Slave_Addr(i2c_master_dev_handle_t *dev_handle, uint8_t Addr)
 {
+    if (dev_handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (handle.bus == NULL) {
+        ESP_LOGE(TAG, "I2C bus not initialized, call DEV_I2C_Init first");
+        return ESP_ERR_INVALID_STATE;
+    }
+
     // Configure the new device address
     i2c_device_config_t i2c_dev_conf = {
         .scl_speed_hz = EXAMPLE_I2C_MASTER_FREQUENCY,  // I2C frequency

--- a/components/io_extension/io_extension.c
+++ b/components/io_extension/io_extension.c
@@ -48,11 +48,19 @@ esp_err_t IO_EXTENSION_IO_Mode(uint8_t pin)
  */
 esp_err_t IO_EXTENSION_Init()
 {
-    // Set the I2C slave address for the IO_EXTENSION device
-    esp_err_t ret = DEV_I2C_Set_Slave_Addr(&IO_EXTENSION.addr, IO_EXTENSION_ADDR);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to set I2C address: %s", esp_err_to_name(ret));
-        return ret;
+    DEV_I2C_Port port = DEV_I2C_Init();
+    if (port.bus == NULL) {
+        ESP_LOGE(TAG, "I2C master bus not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (IO_EXTENSION.addr == NULL) {
+        // Set the I2C slave address for the IO_EXTENSION device only once
+        esp_err_t ret = DEV_I2C_Set_Slave_Addr(&IO_EXTENSION.addr, IO_EXTENSION_ADDR);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set I2C address: %s", esp_err_to_name(ret));
+            return ret;
+        }
     }
 
     if (IO_EXTENSION.addr == NULL) {
@@ -60,7 +68,7 @@ esp_err_t IO_EXTENSION_Init()
         return ESP_ERR_INVALID_STATE;
     }
 
-    ret = IO_EXTENSION_IO_Mode(0xff); // Set all pins to output mode
+    esp_err_t ret = IO_EXTENSION_IO_Mode(0xff); // Set all pins to output mode
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to set IO mode: %s", esp_err_to_name(ret));
         return ret;


### PR DESCRIPTION
## Summary
- guard DEV_I2C_Set_Slave_Addr against missing bus initialization
- initialize the I2C master bus inside IO_EXTENSION_Init before configuring the expander

## Testing
- not run (ESP-IDF toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbdf6e237083239f2f59d5c05e77b3