### PR TITLE
Make IO extension init idempotent

### DIFF
--- a/components/i2c/i2c.c
+++ b/components/i2c/i2c.c
@@ -86,6 +86,27 @@ esp_err_t DEV_I2C_Probe(uint8_t addr)
  */
 esp_err_t DEV_I2C_Set_Slave_Addr(i2c_master_dev_handle_t *dev_handle, uint8_t Addr)
 {
+    if (dev_handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (*dev_handle != NULL) {
+        return ESP_OK;
+    }
+
+    if (handle.bus == NULL) {
+        DEV_I2C_Port port = DEV_I2C_Init();
+        if (port.bus == NULL) {
+            ESP_LOGE(TAG, "I2C bus not initialized");
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+
+    if (Addr > 0x7F) {
+        ESP_LOGE(TAG, "Invalid 7-bit I2C address 0x%02X", Addr);
+        return ESP_ERR_INVALID_ARG;
+    }
+
     // Configure the new device address
     i2c_device_config_t i2c_dev_conf = {
         .scl_speed_hz = EXAMPLE_I2C_MASTER_FREQUENCY,  // I2C frequency
@@ -95,9 +116,16 @@ esp_err_t DEV_I2C_Set_Slave_Addr(i2c_master_dev_handle_t *dev_handle, uint8_t Ad
     // Update the device with the new address and return status
     esp_err_t ret = i2c_master_bus_add_device(handle.bus, &i2c_dev_conf, dev_handle);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "I2C address modification failed");  // Log error if address modification fails
+        ESP_LOGE(TAG, "Failed to add I2C device 0x%02X: %s", Addr, esp_err_to_name(ret));
+        *dev_handle = NULL;
+        return ret;
     }
-    return ret;
+
+    if (handle.dev == NULL) {
+        handle.dev = *dev_handle;
+    }
+
+    return ESP_OK;
 }
 
 /**

--- a/components/io_extension/io_extension.c
+++ b/components/io_extension/io_extension.c
@@ -48,27 +48,41 @@ esp_err_t IO_EXTENSION_IO_Mode(uint8_t pin)
  */
 esp_err_t IO_EXTENSION_Init()
 {
-    // Set the I2C slave address for the IO_EXTENSION device
+    if (IO_EXTENSION.addr != NULL) {
+        return ESP_OK;
+    }
+
+    DEV_I2C_Port port = DEV_I2C_Init();
+    if (port.bus == NULL) {
+        ESP_LOGE(TAG, "I2C master bus not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
     esp_err_t ret = DEV_I2C_Set_Slave_Addr(&IO_EXTENSION.addr, IO_EXTENSION_ADDR);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to set I2C address: %s", esp_err_to_name(ret));
+        IO_EXTENSION.addr = NULL;
         return ret;
-    }
-
-    if (IO_EXTENSION.addr == NULL) {
-        ESP_LOGE(TAG, "IO_EXTENSION address is NULL");
-        return ESP_ERR_INVALID_STATE;
     }
 
     ret = IO_EXTENSION_IO_Mode(0xff); // Set all pins to output mode
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to set IO mode: %s", esp_err_to_name(ret));
+        IO_EXTENSION.addr = NULL;
         return ret;
     }
 
     // Initialize control flags for IO output enable and open-drain output mode
     IO_EXTENSION.Last_io_value = 0xFF; // All pins are initially set to high (output mode)
     IO_EXTENSION.Last_od_value = 0xFF; // All pins are initially set to high (open-drain mode)
+
+    uint8_t data[2] = {IO_EXTENSION_IO_OUTPUT_ADDR, IO_EXTENSION.Last_io_value};
+    ret = DEV_I2C_Write_Nbyte(IO_EXTENSION.addr, data, sizeof(data));
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize IO outputs: %s", esp_err_to_name(ret));
+        IO_EXTENSION.addr = NULL;
+        return ret;
+    }
 
     return ESP_OK;
 }


### PR DESCRIPTION
## Summary
- guard DEV_I2C_Set_Slave_Addr against repeated registrations, invalid addresses, and ensure the master bus is initialized on demand
- make IO_EXTENSION_Init idempotent so the IO expander handle is created once, resets on failure, and programs the output latch after configuring the mode

## Testing
- not run (ESP-IDF toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbdf6e237083239f2f59d5c05e77b3