### PR TITLE
Fix storage component dependency for ESP-IDF 5.5

### DIFF
--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "sd_spi.c"
     INCLUDE_DIRS "include"
-    REQUIRES driver esp_vfs fatfs sdmmc ch422g
+    REQUIRES driver vfs fatfs sdmmc ch422g
 )


### PR DESCRIPTION
## Summary
- replace the deprecated `esp_vfs` build requirement with `vfs` so the storage component resolves under ESP-IDF 5.5

## Testing
- ⚠️ `idf.py reconfigure` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cc372cbe308323bbbbbfa1f412bff6