### PR TITLE
Fix esp_timer dependency declarations

### DIFF
--- a/components/ch422g/CMakeLists.txt
+++ b/components/ch422g/CMakeLists.txt
@@ -2,4 +2,5 @@ idf_component_register(
     SRCS "ch422g.c"
     INCLUDE_DIRS "include"
     REQUIRES driver i2c
+    PRIV_REQUIRES esp_timer
 )

--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -2,4 +2,5 @@ idf_component_register(
     SRCS "sd_spi.c"
     INCLUDE_DIRS "include"
     REQUIRES driver vfs fatfs sdmmc ch422g
+    PRIV_REQUIRES esp_timer
 )


### PR DESCRIPTION
## Summary
- ensure the CH422G expander component declares its dependency on esp_timer for timer APIs
- add the esp_timer private requirement to the storage SPI SD driver to match its use of esp_timer_get_time

## Testing
- idf.py build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7847f730832394ffbb5f40a42e39