### PR TITLE
Fix export label formatting bounds

### DIFF
--- a/main/reptile_game.c
+++ b/main/reptile_game.c
@@ -3076,6 +3076,7 @@ static size_t append_text_to_buffer(char *dst, size_t dst_size, size_t offset,
 
 static void format_regulations_export_label(char *dst, size_t dst_size,
                                             const char *time_buf,
+                                            size_t time_buf_size,
                                             const char *path) {
   static const char prefix[] = "Dernier export: ";
   static const char open_paren[] = " (";
@@ -3091,9 +3092,9 @@ static void format_regulations_export_label(char *dst, size_t dst_size,
 
   size_t len = 0U;
   len = append_text_to_buffer(dst, dst_size, len, prefix, sizeof(prefix) - 1U);
-  if (time_buf) {
-    len = append_text_to_buffer(dst, dst_size, len, time_buf,
-                                strnlen(time_buf, dst_size));
+  if (time_buf && time_buf_size > 0U) {
+    size_t time_len = strnlen(time_buf, time_buf_size);
+    len = append_text_to_buffer(dst, dst_size, len, time_buf, time_len);
   }
 
   if (!path || path[0] == '\0') {
@@ -3411,6 +3412,7 @@ static void update_regulation_screen(void) {
         localtime_r(&regulations_last_export_time, &tm_info);
         strftime(time_buf, sizeof(time_buf), "%d/%m %H:%M", &tm_info);
         format_regulations_export_label(text, sizeof(text), time_buf,
+                                        sizeof(time_buf),
                                         regulations_last_export_path);
       }
       lv_label_set_text(regulations_export_label, text);


### PR DESCRIPTION
## Summary
- add an explicit time buffer length parameter when formatting the regulation export label
- use the provided time buffer size to avoid potential over-read diagnostics during build

## Testing
- not run (ESP-IDF toolchain is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceb32160288323910c3cbd6192ce1e