### PR TITLE
Update LVGL integration to 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,14 @@ L'état complet est persisté sur microSD via `reptile_facility_save` et
 ## Prérequis
 ### Logiciel
 - **ESP-IDF 5.5** installé et initialisé (`. ./export.sh`).
-- **LVGL 8.3.9** via le gestionnaire de composants (`idf_component.yml`).
+- **LVGL 9.x** via le gestionnaire de composants (`idf_component.yml`). Synchronisez la dépendance avec `idf.py add-dependency lvgl/lvgl^9` puis `idf.py reconfigure` ; l'abstraction entre les API LVGL 8/9 est centralisée dans `main/lvgl_compat.*`.
+
+#### Initialisation de la dépendance LVGL 9.x
+```sh
+idf.py add-dependency lvgl/lvgl^9
+idf.py reconfigure
+```
+Ces commandes assurent l'installation de LVGL 9.x dans `managed_components/` selon la version déclarée dans `idf_component.yml`.
 
 ### Matériel
 - Carte de développement ESP32‑S3.

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,5 +2,5 @@ dependencies:
   idf:
     version: "^5.5"
   lvgl/lvgl:
-    version: "8.3.9"
+    version: "^9"
 

--- a/main/main.c
+++ b/main/main.c
@@ -3,7 +3,7 @@
  * | Author     :   Waveshare team
  * | Function   :   Main function
  * | Info       :
- * |                Ported LVGL 8.3.9 and display the official demo interface
+ * |                Ported LVGL 9.x demos with compatibility wrappers
  *----------------
  * | Version    :   V1.0
  * | Date       :   2024-12-06


### PR DESCRIPTION
## Summary
- update the README to reference LVGL 9.x, document the `lvgl_compat` abstraction, and add dependency sync commands
- align `main/idf_component.yml` with the LVGL 9.x range used by the project
- refresh the main.c banner comment to reference the LVGL 9.x demo port

## Testing
- not run (idf.py not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf0b65d7ac8323bc22e9bf49e6109a