### PR TITLE
Refine CAN receive API and add host test

### DIFF
--- a/components/can/can.h
+++ b/components/can/can.h
@@ -64,11 +64,14 @@ uint32_t can_read_alerts();
 esp_err_t can_write_Byte(can_message_t message);
 
 /**
- * @brief Reads a single byte of data from the CAN interface.
+ * @brief Attempts to read a CAN frame from the interface.
  *
- * @return A CAN message containing the received data.
+ * @param[out] message Destination for the received CAN frame.
+ *
+ * @return ESP_OK when a frame has been copied into @p message, otherwise the
+ *         error code returned by the underlying TWAI driver.
  */
-can_message_t can_read_Byte();
+esp_err_t can_read_Byte(can_message_t *message);
 
 bool can_is_active(void);
 

--- a/tests/include/driver/twai.h
+++ b/tests/include/driver/twai.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <limits.h>
+
+#include "esp_err.h"
+
+typedef uint32_t TickType_t;
+
+typedef struct {
+    uint32_t clk_src_hz;
+} twai_timing_config_t;
+
+typedef struct {
+    uint32_t acceptance_code;
+} twai_filter_config_t;
+
+typedef struct {
+    uint32_t mode;
+} twai_general_config_t;
+
+typedef struct {
+    uint32_t identifier;
+    uint8_t data_length_code;
+    uint8_t data[8];
+    uint32_t flags;
+    bool extd;
+    bool rtr;
+} twai_message_t;
+
+typedef struct {
+    uint32_t bus_error_count;
+    uint32_t msgs_to_tx;
+} twai_status_info_t;
+
+#define pdMS_TO_TICKS(ms) (ms)
+#define portMAX_DELAY UINT32_MAX
+
+#define TWAI_ALERT_TX_SUCCESS   (1u << 0)
+#define TWAI_ALERT_TX_FAILED    (1u << 1)
+#define TWAI_ALERT_RX_DATA      (1u << 2)
+#define TWAI_ALERT_RX_QUEUE_FULL (1u << 3)
+#define TWAI_ALERT_ERR_PASS     (1u << 4)
+#define TWAI_ALERT_BUS_ERROR    (1u << 5)
+
+#define TWAI_MSG_FLAG_NONE 0u
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+esp_err_t twai_driver_install(const twai_general_config_t *g_config,
+                              const twai_timing_config_t *t_config,
+                              const twai_filter_config_t *f_config);
+
+esp_err_t twai_start(void);
+
+esp_err_t twai_reconfigure_alerts(uint32_t alerts, uint32_t *old_alerts);
+
+esp_err_t twai_read_alerts(uint32_t *alerts, TickType_t ticks_to_wait);
+
+esp_err_t twai_get_status_info(twai_status_info_t *status_info);
+
+esp_err_t twai_transmit(const twai_message_t *message, TickType_t ticks_to_wait);
+
+esp_err_t twai_receive(twai_message_t *message, TickType_t ticks_to_wait);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/tests/include/esp_err.h
+++ b/tests/include/esp_err.h
@@ -10,6 +10,7 @@ typedef int32_t esp_err_t;
 #define ESP_ERR_NO_MEM 0x103
 #define ESP_ERR_NOT_FOUND 0x104
 #define ESP_ERR_INVALID_STATE 0x105
+#define ESP_ERR_TIMEOUT 0x107
 
 static inline const char *esp_err_to_name(esp_err_t err) {
   switch (err) {

--- a/tests/include/i2c.h
+++ b/tests/include/i2c.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef void *i2c_master_dev_handle_t;

--- a/tests/include/io_extension.h
+++ b/tests/include/io_extension.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "esp_err.h"
+#include "i2c.h"
+
+typedef struct _io_extension_obj_t {
+    i2c_master_dev_handle_t addr;
+    uint8_t Last_io_value;
+    uint8_t Last_od_value;
+} io_extension_obj_t;
+
+static inline esp_err_t IO_EXTENSION_Init(void)
+{
+    return ESP_OK;
+}
+
+static inline esp_err_t IO_EXTENSION_Output(uint8_t pin, uint8_t value)
+{
+    (void)pin;
+    (void)value;
+    return ESP_OK;
+}
+
+static inline esp_err_t IO_EXTENSION_Input(uint8_t pin, uint8_t *value)
+{
+    (void)pin;
+    if (value)
+    {
+        *value = 0;
+    }
+    return ESP_OK;
+}
+
+static inline esp_err_t IO_EXTENSION_Pwm_Output(uint8_t value)
+{
+    (void)value;
+    return ESP_OK;
+}
+
+static inline esp_err_t IO_EXTENSION_Adc_Input(uint16_t *value)
+{
+    if (value)
+    {
+        *value = 0;
+    }
+    return ESP_OK;
+}

--- a/tests/test_can_read.c
+++ b/tests/test_can_read.c
@@ -1,0 +1,142 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "can.h"
+
+static esp_err_t g_stub_receive_status = ESP_ERR_TIMEOUT;
+static twai_message_t g_stub_receive_message;
+static bool g_stub_receive_has_message = false;
+
+static void twai_stub_set_receive_result(esp_err_t status,
+                                         const twai_message_t *message)
+{
+    g_stub_receive_status = status;
+    if (message)
+    {
+        g_stub_receive_message = *message;
+        g_stub_receive_has_message = true;
+    }
+    else
+    {
+        memset(&g_stub_receive_message, 0, sizeof(g_stub_receive_message));
+        g_stub_receive_has_message = false;
+    }
+}
+
+esp_err_t twai_driver_install(const twai_general_config_t *g_config,
+                              const twai_timing_config_t *t_config,
+                              const twai_filter_config_t *f_config)
+{
+    (void)g_config;
+    (void)t_config;
+    (void)f_config;
+    return ESP_OK;
+}
+
+esp_err_t twai_start(void)
+{
+    return ESP_OK;
+}
+
+esp_err_t twai_reconfigure_alerts(uint32_t alerts, uint32_t *old_alerts)
+{
+    if (old_alerts)
+    {
+        *old_alerts = alerts;
+    }
+    return ESP_OK;
+}
+
+esp_err_t twai_read_alerts(uint32_t *alerts, TickType_t ticks_to_wait)
+{
+    (void)ticks_to_wait;
+    if (alerts)
+    {
+        *alerts = 0;
+    }
+    return ESP_OK;
+}
+
+esp_err_t twai_get_status_info(twai_status_info_t *status_info)
+{
+    if (status_info)
+    {
+        status_info->bus_error_count = 0;
+        status_info->msgs_to_tx = 0;
+    }
+    return ESP_OK;
+}
+
+esp_err_t twai_transmit(const twai_message_t *message, TickType_t ticks_to_wait)
+{
+    (void)message;
+    (void)ticks_to_wait;
+    return ESP_OK;
+}
+
+esp_err_t twai_receive(twai_message_t *message, TickType_t ticks_to_wait)
+{
+    (void)ticks_to_wait;
+    if ((g_stub_receive_status == ESP_OK) && message && g_stub_receive_has_message)
+    {
+        *message = g_stub_receive_message;
+        g_stub_receive_has_message = false;
+    }
+    return g_stub_receive_status;
+}
+
+static void test_no_frame_keeps_callers_buffer_pristine(void)
+{
+    can_message_t msg;
+    memset(&msg, 0xA5, sizeof(msg));
+    uint8_t snapshot[sizeof(msg)];
+    memcpy(snapshot, &msg, sizeof(msg));
+
+    twai_stub_set_receive_result(ESP_ERR_TIMEOUT, NULL);
+
+    esp_err_t status = can_read_Byte(&msg);
+    assert(status == ESP_ERR_TIMEOUT);
+    assert(memcmp(snapshot, &msg, sizeof(msg)) == 0);
+}
+
+static void test_frame_copied_once_and_preserved_on_timeout(void)
+{
+    can_message_t msg;
+    memset(&msg, 0, sizeof(msg));
+
+    twai_message_t frame = {
+        .identifier = 0x123,
+        .data_length_code = 3,
+        .data = {0xDE, 0xAD, 0xBE},
+        .flags = TWAI_MSG_FLAG_NONE,
+        .extd = false,
+        .rtr = false,
+    };
+
+    twai_stub_set_receive_result(ESP_OK, &frame);
+
+    esp_err_t status = can_read_Byte(&msg);
+    assert(status == ESP_OK);
+    assert(msg.identifier == frame.identifier);
+    assert(msg.data_length_code == frame.data_length_code);
+    assert(memcmp(msg.data, frame.data, frame.data_length_code) == 0);
+
+    can_message_t preserved = msg;
+
+    twai_stub_set_receive_result(ESP_ERR_TIMEOUT, NULL);
+
+    status = can_read_Byte(&msg);
+    assert(status == ESP_ERR_TIMEOUT);
+    assert(memcmp(&msg, &preserved, sizeof(msg)) == 0);
+}
+
+int main(void)
+{
+    test_no_frame_keeps_callers_buffer_pristine();
+    test_frame_copied_once_and_preserved_on_timeout();
+    puts("can_read_Byte tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- return an esp_err_t status from `can_read_Byte`, only copying frames when the TWAI driver reports data and keeping the caller buffer deterministic otherwise
- update the CAN component header for the new signature and add host-side TWAI/io-extension shims required for simulation builds
- introduce a host unit test validating that empty receive calls no longer leak uninitialised CAN frame contents

## Testing
- `gcc -std=c11 -Wall -Wextra -Itests/include -Icomponents/can -Icomponents -I. tests/test_can_read.c components/can/can.c -o tests/test_can_read`
- `tests/test_can_read`


------
https://chatgpt.com/codex/tasks/task_e_68cf0fcc89188323b35fac7c02dbb06a