### PR TITLE
feat: support multi-channel actuator routing

### DIFF
--- a/components/env_control/env_control.c
+++ b/components/env_control/env_control.c
@@ -162,9 +162,7 @@ static void update_alarm_flags(terrarium_ctrl_t *terr)
 
 static void apply_uv_gpio(size_t index, bool on)
 {
-    if (index == 0) {
-        reptile_uv_gpio(on);
-    }
+    reptile_uv_gpio_channel(index, on);
 }
 
 static esp_err_t start_heat_cycle_locked(terrarium_ctrl_t *terr, bool manual)
@@ -317,11 +315,7 @@ static void heat_task(void *ctx)
     size_t idx = terr->index;
     notify_state(idx);
     time_t start = time(NULL);
-    if (idx == 0) {
-        reptile_heat_gpio();
-    } else {
-        vTaskDelay(pdMS_TO_TICKS(5000));
-    }
+    reptile_heat_gpio_channel(idx);
     time_t end = time(NULL);
     double duration = difftime(end, start);
     if (duration < 0) {
@@ -344,11 +338,7 @@ static void pump_task(void *ctx)
     size_t idx = terr->index;
     notify_state(idx);
     time_t start = time(NULL);
-    if (idx == 0) {
-        reptile_water_gpio();
-    } else {
-        vTaskDelay(pdMS_TO_TICKS(1500));
-    }
+    reptile_water_gpio_channel(idx);
     time_t end = time(NULL);
     double duration = difftime(end, start);
     if (duration < 0) {

--- a/components/gpio/gpio.c
+++ b/components/gpio/gpio.c
@@ -1,9 +1,11 @@
 #include "gpio.h"
 #include "game_mode.h"
+#include "esp_log.h"
 
 extern const actuator_driver_t gpio_real_driver;
 extern const actuator_driver_t gpio_sim_driver;
 
+static const char *TAG = "gpio";
 static const actuator_driver_t *s_driver = NULL;
 
 static void gpio_select_driver(void)
@@ -56,36 +58,88 @@ uint8_t DEV_Digital_Read(uint16_t Pin)
     return 0;
 }
 
-void reptile_feed_gpio(void)
+static bool channel_supported(size_t channel)
 {
     gpio_select_driver();
-    if (s_driver && s_driver->feed) {
-        s_driver->feed();
+    if (!s_driver) {
+        return false;
     }
+    size_t max_channels = s_driver->channel_count;
+    if (max_channels == 0 || channel < max_channels) {
+        return true;
+    }
+    ESP_LOGW(TAG,
+             "Actuator channel %zu ignored (driver supports %zu channel%s)",
+             channel,
+             max_channels,
+             max_channels > 1 ? "s" : "");
+    return false;
+}
+
+void reptile_feed_gpio_channel(size_t channel)
+{
+    if (!channel_supported(channel)) {
+        return;
+    }
+    if (s_driver->feed) {
+        s_driver->feed(channel);
+    }
+}
+
+void reptile_water_gpio_channel(size_t channel)
+{
+    if (!channel_supported(channel)) {
+        return;
+    }
+    if (s_driver->water) {
+        s_driver->water(channel);
+    }
+}
+
+void reptile_heat_gpio_channel(size_t channel)
+{
+    if (!channel_supported(channel)) {
+        return;
+    }
+    if (s_driver->heat) {
+        s_driver->heat(channel);
+    }
+}
+
+void reptile_uv_gpio_channel(size_t channel, bool on)
+{
+    if (!channel_supported(channel)) {
+        return;
+    }
+    if (s_driver->uv) {
+        s_driver->uv(channel, on);
+    }
+}
+
+void reptile_feed_gpio(void)
+{
+    reptile_feed_gpio_channel(0);
 }
 
 void reptile_water_gpio(void)
 {
-    gpio_select_driver();
-    if (s_driver && s_driver->water) {
-        s_driver->water();
-    }
+    reptile_water_gpio_channel(0);
 }
 
 void reptile_heat_gpio(void)
 {
-    gpio_select_driver();
-    if (s_driver && s_driver->heat) {
-        s_driver->heat();
-    }
+    reptile_heat_gpio_channel(0);
 }
 
 void reptile_uv_gpio(bool on)
 {
+    reptile_uv_gpio_channel(0, on);
+}
+
+size_t reptile_actuator_channel_count(void)
+{
     gpio_select_driver();
-    if (s_driver && s_driver->uv) {
-        s_driver->uv(on);
-    }
+    return s_driver ? s_driver->channel_count : 0u;
 }
 
 void reptile_actuators_deinit(void)

--- a/components/gpio/gpio.h
+++ b/components/gpio/gpio.h
@@ -16,6 +16,7 @@
 
 #include "driver/gpio.h"  // ESP-IDF GPIO driver library
 #include "esp_err.h"
+#include <stdbool.h>
 #include <stddef.h>
 
 /* Pin Definitions */
@@ -23,6 +24,10 @@
 #define SERVO_FEED_PIN   GPIO_NUM_17 /* Servo control pin for feeding */
 #define WATER_PUMP_PIN   GPIO_NUM_18 /* Pump control pin for watering */
 #define HEAT_RES_PIN     GPIO_NUM_19 /* Heating resistor control pin */
+
+/* Default pulse widths (in milliseconds) applied to monostable actuators */
+#define REPTILE_GPIO_HEAT_PULSE_MS 5000u
+#define REPTILE_GPIO_PUMP_PULSE_MS 1000u
 
 /* Function Prototypes */
 
@@ -32,11 +37,12 @@ typedef struct {
     void (*gpio_int)(int32_t pin, gpio_isr_t isr_handler);
     void (*digital_write)(uint16_t pin, uint8_t value);
     uint8_t (*digital_read)(uint16_t pin);
-    void (*feed)(void);
-    void (*water)(void);
-    void (*heat)(void);
-    void (*uv)(bool on);
+    void (*feed)(size_t channel);
+    void (*water)(size_t channel);
+    void (*heat)(size_t channel);
+    void (*uv)(size_t channel, bool on);
     void (*deinit)(void);
+    size_t channel_count;
 } actuator_driver_t;
 
 void DEV_GPIO_Mode(uint16_t Pin, uint16_t Mode);
@@ -47,6 +53,11 @@ void reptile_feed_gpio(void);
 void reptile_water_gpio(void);
 void reptile_heat_gpio(void);
 void reptile_uv_gpio(bool on);
+void reptile_feed_gpio_channel(size_t channel);
+void reptile_water_gpio_channel(size_t channel);
+void reptile_heat_gpio_channel(size_t channel);
+void reptile_uv_gpio_channel(size_t channel, bool on);
+size_t reptile_actuator_channel_count(void);
 esp_err_t reptile_actuators_init(void);
 void reptile_actuators_deinit(void);
 

--- a/components/gpio/gpio_real.c
+++ b/components/gpio/gpio_real.c
@@ -1,6 +1,48 @@
 #include "gpio.h"
+
+#include "ch422g.h"
+#include "esp_check.h"
+#include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+
+#define TAG "gpio_real"
+
+typedef enum {
+    REPTILE_OUTPUT_NONE = 0,
+    REPTILE_OUTPUT_GPIO,
+    REPTILE_OUTPUT_CH422,
+} reptile_output_bus_t;
+
+typedef struct {
+    reptile_output_bus_t bus;
+    bool active_high;
+    union {
+        gpio_num_t gpio;
+        uint8_t exio;
+    } signal;
+} reptile_output_t;
+
+typedef struct {
+    reptile_output_t heater;
+    reptile_output_t pump;
+    reptile_output_t uv;
+} reptile_channel_hw_t;
+
+static const reptile_channel_hw_t s_hw_map[] = {
+    {
+        .heater = {.bus = REPTILE_OUTPUT_GPIO, .active_high = true, .signal.gpio = HEAT_RES_PIN},
+        .pump = {.bus = REPTILE_OUTPUT_GPIO, .active_high = true, .signal.gpio = WATER_PUMP_PIN},
+        .uv = {.bus = REPTILE_OUTPUT_GPIO, .active_high = true, .signal.gpio = LED_GPIO_PIN},
+    },
+    {
+        .heater = {.bus = REPTILE_OUTPUT_CH422, .active_high = false, .signal.exio = 1},
+        .pump = {.bus = REPTILE_OUTPUT_CH422, .active_high = false, .signal.exio = 2},
+        .uv = {.bus = REPTILE_OUTPUT_CH422, .active_high = false, .signal.exio = 3},
+    },
+};
+
+static const size_t s_hw_channel_count = sizeof(s_hw_map) / sizeof(s_hw_map[0]);
 
 static void gpio_real_mode(uint16_t Pin, uint16_t Mode)
 {
@@ -52,56 +94,200 @@ static uint8_t gpio_real_read(uint16_t Pin)
     return gpio_get_level(Pin);
 }
 
-static void gpio_real_feed(void)
+static inline bool actuator_available(const reptile_output_t *out)
 {
-    gpio_set_level(SERVO_FEED_PIN, 1);
+    return out && out->bus != REPTILE_OUTPUT_NONE;
+}
+
+static inline uint8_t actuator_gpio_level(const reptile_output_t *out, bool active)
+{
+    bool level_high = (out->active_high == active);
+    return level_high ? 1u : 0u;
+}
+
+static esp_err_t actuator_drive(const reptile_output_t *out, bool active)
+{
+    if (!actuator_available(out)) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    switch (out->bus) {
+    case REPTILE_OUTPUT_GPIO:
+        gpio_set_level(out->signal.gpio, actuator_gpio_level(out, active));
+        return ESP_OK;
+    case REPTILE_OUTPUT_CH422: {
+        bool level = (out->active_high == active);
+        return ch422g_exio_set(out->signal.exio, level);
+    }
+    case REPTILE_OUTPUT_NONE:
+    default:
+        return ESP_ERR_INVALID_STATE;
+    }
+}
+
+static void configure_idle_state(const reptile_output_t *out)
+{
+    if (!actuator_available(out)) {
+        return;
+    }
+    if (out->bus == REPTILE_OUTPUT_GPIO) {
+        gpio_real_mode(out->signal.gpio, GPIO_MODE_OUTPUT);
+    }
+    esp_err_t err = actuator_drive(out, false);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "Failed to set idle state (bus=%d, err=%s)", out->bus, esp_err_to_name(err));
+    }
+}
+
+static bool channel_valid(size_t channel)
+{
+    if (channel < s_hw_channel_count) {
+        return true;
+    }
+    ESP_LOGW(TAG,
+             "Terrarium channel %zu out of range (configured %zu)",
+             channel,
+             s_hw_channel_count);
+    return false;
+}
+
+static const reptile_channel_hw_t *get_channel(size_t channel)
+{
+    if (!channel_valid(channel)) {
+        return NULL;
+    }
+    return &s_hw_map[channel];
+}
+
+static void gpio_real_feed(size_t channel)
+{
+    if (channel != 0) {
+        ESP_LOGW(TAG, "Feed actuator not mapped for terrarium %zu", channel);
+        return;
+    }
+    gpio_real_mode(SERVO_FEED_PIN, GPIO_MODE_OUTPUT);
+    gpio_real_write(SERVO_FEED_PIN, 1);
     vTaskDelay(pdMS_TO_TICKS(1000));
-    gpio_set_level(SERVO_FEED_PIN, 0);
+    gpio_real_write(SERVO_FEED_PIN, 0);
 }
 
-static void gpio_real_water(void)
+static void gpio_real_water(size_t channel)
 {
-    gpio_set_level(WATER_PUMP_PIN, 1);
-    vTaskDelay(pdMS_TO_TICKS(1000));
-    gpio_set_level(WATER_PUMP_PIN, 0);
+    const reptile_channel_hw_t *hw = get_channel(channel);
+    if (!hw || !actuator_available(&hw->pump)) {
+        ESP_LOGW(TAG, "Pump actuator unavailable for terrarium %zu", channel);
+        return;
+    }
+    esp_err_t err = actuator_drive(&hw->pump, true);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to enable pump channel %zu: %s", channel, esp_err_to_name(err));
+        return;
+    }
+    vTaskDelay(pdMS_TO_TICKS(REPTILE_GPIO_PUMP_PULSE_MS));
+    err = actuator_drive(&hw->pump, false);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to disable pump channel %zu: %s", channel, esp_err_to_name(err));
+    }
 }
 
-static void gpio_real_heat(void)
+static void gpio_real_heat(size_t channel)
 {
-    gpio_set_level(HEAT_RES_PIN, 1);
-    vTaskDelay(pdMS_TO_TICKS(5000));
-    gpio_set_level(HEAT_RES_PIN, 0);
+    const reptile_channel_hw_t *hw = get_channel(channel);
+    if (!hw || !actuator_available(&hw->heater)) {
+        ESP_LOGW(TAG, "Heater actuator unavailable for terrarium %zu", channel);
+        return;
+    }
+    esp_err_t err = actuator_drive(&hw->heater, true);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to enable heater channel %zu: %s", channel, esp_err_to_name(err));
+        return;
+    }
+    vTaskDelay(pdMS_TO_TICKS(REPTILE_GPIO_HEAT_PULSE_MS));
+    err = actuator_drive(&hw->heater, false);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to disable heater channel %zu: %s", channel, esp_err_to_name(err));
+    }
 }
 
-static void gpio_real_uv(bool on)
+static void gpio_real_uv(size_t channel, bool on)
 {
-    gpio_set_level(LED_GPIO_PIN, on ? 1 : 0);
+    const reptile_channel_hw_t *hw = get_channel(channel);
+    if (!hw || !actuator_available(&hw->uv)) {
+        ESP_LOGW(TAG, "UV actuator unavailable for terrarium %zu", channel);
+        return;
+    }
+    esp_err_t err = actuator_drive(&hw->uv, on);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG,
+                 "Failed to set UV channel %zu to %s: %s",
+                 channel,
+                 on ? "ON" : "OFF",
+                 esp_err_to_name(err));
+    }
 }
 
 static esp_err_t gpio_real_init(void)
 {
     gpio_real_mode(SERVO_FEED_PIN, GPIO_MODE_OUTPUT);
-    gpio_real_mode(WATER_PUMP_PIN, GPIO_MODE_OUTPUT);
-    gpio_real_mode(HEAT_RES_PIN, GPIO_MODE_OUTPUT);
-    gpio_real_mode(LED_GPIO_PIN, GPIO_MODE_OUTPUT);
     gpio_real_write(SERVO_FEED_PIN, 0);
-    gpio_real_write(WATER_PUMP_PIN, 0);
-    gpio_real_write(HEAT_RES_PIN, 0);
-    gpio_real_write(LED_GPIO_PIN, 0);
+
+    bool need_ch422 = false;
+    for (size_t i = 0; i < s_hw_channel_count; ++i) {
+        const reptile_channel_hw_t *hw = &s_hw_map[i];
+        const reptile_output_t *outputs[] = {&hw->heater, &hw->pump, &hw->uv};
+        for (size_t j = 0; j < sizeof(outputs) / sizeof(outputs[0]); ++j) {
+            const reptile_output_t *out = outputs[j];
+            if (!actuator_available(out)) {
+                continue;
+            }
+            if (out->bus == REPTILE_OUTPUT_CH422) {
+                need_ch422 = true;
+            } else if (out->bus == REPTILE_OUTPUT_GPIO) {
+                gpio_real_mode(out->signal.gpio, GPIO_MODE_OUTPUT);
+            }
+        }
+    }
+
+    if (need_ch422) {
+        ESP_RETURN_ON_ERROR(ch422g_init(), TAG, "init CH422G expander");
+    }
+
+    for (size_t i = 0; i < s_hw_channel_count; ++i) {
+        const reptile_channel_hw_t *hw = &s_hw_map[i];
+        configure_idle_state(&hw->heater);
+        configure_idle_state(&hw->pump);
+        configure_idle_state(&hw->uv);
+    }
+
     return ESP_OK;
 }
 
 static void gpio_real_deinit(void)
 {
-    gpio_real_write(WATER_PUMP_PIN, 0);
-    gpio_real_write(HEAT_RES_PIN, 0);
-    gpio_real_write(SERVO_FEED_PIN, 0);
-    gpio_real_write(LED_GPIO_PIN, 0);
+    for (size_t i = 0; i < s_hw_channel_count; ++i) {
+        const reptile_channel_hw_t *hw = &s_hw_map[i];
+        if (actuator_available(&hw->heater)) {
+            actuator_drive(&hw->heater, false);
+            if (hw->heater.bus == REPTILE_OUTPUT_GPIO) {
+                gpio_real_mode(hw->heater.signal.gpio, GPIO_MODE_INPUT);
+            }
+        }
+        if (actuator_available(&hw->pump)) {
+            actuator_drive(&hw->pump, false);
+            if (hw->pump.bus == REPTILE_OUTPUT_GPIO) {
+                gpio_real_mode(hw->pump.signal.gpio, GPIO_MODE_INPUT);
+            }
+        }
+        if (actuator_available(&hw->uv)) {
+            actuator_drive(&hw->uv, false);
+            if (hw->uv.bus == REPTILE_OUTPUT_GPIO) {
+                gpio_real_mode(hw->uv.signal.gpio, GPIO_MODE_INPUT);
+            }
+        }
+    }
 
-    gpio_real_mode(WATER_PUMP_PIN, GPIO_MODE_INPUT);
-    gpio_real_mode(HEAT_RES_PIN, GPIO_MODE_INPUT);
+    gpio_real_write(SERVO_FEED_PIN, 0);
     gpio_real_mode(SERVO_FEED_PIN, GPIO_MODE_INPUT);
-    gpio_real_mode(LED_GPIO_PIN, GPIO_MODE_INPUT);
 }
 
 const actuator_driver_t gpio_real_driver = {
@@ -115,5 +301,5 @@ const actuator_driver_t gpio_real_driver = {
     .heat = gpio_real_heat,
     .uv = gpio_real_uv,
     .deinit = gpio_real_deinit,
+    .channel_count = sizeof(s_hw_map) / sizeof(s_hw_map[0]),
 };
-

--- a/components/gpio/gpio_sim.c
+++ b/components/gpio/gpio_sim.c
@@ -1,13 +1,27 @@
 #include "gpio.h"
 #include "esp_log.h"
-#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include <stdbool.h>
+#include <string.h>
 
 static const char *TAG = "gpio_sim";
 static uint8_t s_levels[256];
-static bool s_heater_state;
-static bool s_pump_state;
-static bool s_uv_state;
+
+#define SIM_MAX_CHANNELS 4
+
+static bool s_heater_state[SIM_MAX_CHANNELS];
+static bool s_pump_state[SIM_MAX_CHANNELS];
+static bool s_uv_state[SIM_MAX_CHANNELS];
+
+static bool sim_channel_valid(size_t channel)
+{
+    if (channel < SIM_MAX_CHANNELS) {
+        return true;
+    }
+    ESP_LOGW(TAG, "Simulated actuator channel %zu exceeds %u", channel, SIM_MAX_CHANNELS);
+    return false;
+}
 
 static void gpio_sim_mode(uint16_t Pin, uint16_t Mode)
 {
@@ -25,13 +39,13 @@ static void gpio_sim_write(uint16_t Pin, uint8_t Value)
 {
     s_levels[Pin & 0xFF] = Value;
     if (Pin == HEAT_RES_PIN) {
-        s_heater_state = Value;
+        s_heater_state[0] = Value;
     }
     if (Pin == WATER_PUMP_PIN) {
-        s_pump_state = Value;
+        s_pump_state[0] = Value;
     }
     if (Pin == LED_GPIO_PIN) {
-        s_uv_state = Value;
+        s_uv_state[0] = Value;
     }
 }
 
@@ -42,54 +56,76 @@ static uint8_t gpio_sim_read(uint16_t Pin)
 
 bool gpio_sim_get_heater_state(void)
 {
-    return s_heater_state;
+    return s_heater_state[0];
 }
 
 bool gpio_sim_get_pump_state(void)
 {
-    return s_pump_state;
+    return s_pump_state[0];
 }
 
 bool gpio_sim_get_uv_state(void)
 {
-    return s_uv_state;
+    return s_uv_state[0];
 }
 
-static void gpio_sim_feed(void)
+static void gpio_sim_feed(size_t channel)
 {
-    ESP_LOGI(TAG, "Simulated feed");
+    if (!sim_channel_valid(channel)) {
+        return;
+    }
+    if (channel != 0) {
+        ESP_LOGW(TAG, "Feed actuator not modelled for channel %zu", channel);
+        return;
+    }
+    ESP_LOGI(TAG, "Simulated feed on channel %zu", channel);
 }
 
-static void gpio_sim_water(void)
+static void gpio_sim_water(size_t channel)
 {
-    ESP_LOGI(TAG, "Simulated water");
+    if (!sim_channel_valid(channel)) {
+        return;
+    }
+    ESP_LOGI(TAG, "Simulated water on channel %zu", channel);
+    s_pump_state[channel] = true;
+    vTaskDelay(pdMS_TO_TICKS(REPTILE_GPIO_PUMP_PULSE_MS));
+    s_pump_state[channel] = false;
 }
 
-static void gpio_sim_heat(void)
+static void gpio_sim_heat(size_t channel)
 {
-    ESP_LOGI(TAG, "Simulated heat");
+    if (!sim_channel_valid(channel)) {
+        return;
+    }
+    ESP_LOGI(TAG, "Simulated heat on channel %zu", channel);
+    s_heater_state[channel] = true;
+    vTaskDelay(pdMS_TO_TICKS(REPTILE_GPIO_HEAT_PULSE_MS));
+    s_heater_state[channel] = false;
 }
 
-static void gpio_sim_uv(bool on)
+static void gpio_sim_uv(size_t channel, bool on)
 {
-    ESP_LOGI(TAG, "Simulated UV %s", on ? "ON" : "OFF");
-    s_uv_state = on;
+    if (!sim_channel_valid(channel)) {
+        return;
+    }
+    ESP_LOGI(TAG, "Simulated UV %s on channel %zu", on ? "ON" : "OFF", channel);
+    s_uv_state[channel] = on;
 }
 
 static void gpio_sim_deinit(void)
 {
     memset(s_levels, 0, sizeof(s_levels));
-    s_heater_state = false;
-    s_pump_state = false;
-    s_uv_state = false;
+    memset(s_heater_state, 0, sizeof(s_heater_state));
+    memset(s_pump_state, 0, sizeof(s_pump_state));
+    memset(s_uv_state, 0, sizeof(s_uv_state));
 }
 
 static esp_err_t gpio_sim_init(void)
 {
     memset(s_levels, 0, sizeof(s_levels));
-    s_heater_state = false;
-    s_pump_state = false;
-    s_uv_state = false;
+    memset(s_heater_state, 0, sizeof(s_heater_state));
+    memset(s_pump_state, 0, sizeof(s_pump_state));
+    memset(s_uv_state, 0, sizeof(s_uv_state));
     return ESP_OK;
 }
 
@@ -104,5 +140,6 @@ const actuator_driver_t gpio_sim_driver = {
     .heat = gpio_sim_heat,
     .uv = gpio_sim_uv,
     .deinit = gpio_sim_deinit,
+    .channel_count = SIM_MAX_CHANNELS,
 };
 


### PR DESCRIPTION
## Summary
- route environment control heat, pump and UV tasks through new per-channel GPIO hooks
- extend the GPIO facade with channel-aware actuator APIs and expose driver channel counts
- teach the real GPIO driver to map multiple terrarium channels (GPIO + CH422G) while the simulator mirrors the multi-channel behaviour

## Testing
- ⚠️ `idf.py build` *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf12584300832385202c8565e0fe87