### PR TITLE
Fix gpio component dependency on ch422g

### DIFF
--- a/components/gpio/CMakeLists.txt
+++ b/components/gpio/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "gpio.c" "gpio_real.c" "gpio_sim.c"
                         INCLUDE_DIRS "."
                         REQUIRES driver freertos esp_system
-                        PRIV_REQUIRES config
+                        PRIV_REQUIRES config ch422g
                     )


### PR DESCRIPTION
## Summary
- add the ch422g component as a private dependency of the gpio component so its headers are available during the build
- unblock compilation errors caused by gpio_real.c including ch422g.h

## Testing
- not run (idf.py not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cf1609508c8323b85248985f4eeb21