### PR TITLE
Improve I2C bus resilience and CH422G detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Ces étapes garantissent la libération du port avant de relancer le moniteur ES
   l'extenseur et numéro d'EXIO pilotant la ligne CS du lecteur microSD.
 - `CONFIG_STORAGE_SD_USE_GPIO_CS` + `CONFIG_STORAGE_SD_GPIO_CS_NUM` : bypass du
   CH422G au profit d'un GPIO direct pour la CS microSD (câblage nécessaire).
+- Le pilote I²C déclenche automatiquement une récupération matérielle lorsque SDA/SCL
+  restent bloquées (clock stretch infini, périphérique en erreur). Toutes les handles
+  enregistrées (CH422G, multiplexeur, GT911…) sont relâchées puis recréées pour que
+  le bus reparte proprement après réparation du câblage.
 
 ## Menu de démarrage et modes d'exécution
 Au reset, le firmware présente un tableau de bord structuré : en-tête flex affichant le logo, l'heure

--- a/components/i2c/i2c.h
+++ b/components/i2c/i2c.h
@@ -61,6 +61,19 @@ typedef struct {
 DEV_I2C_Port DEV_I2C_Init();
 
 /**
+ * @brief Attempt to recover the I2C bus when SCL/SDA are held low.
+ *
+ * The routine releases any registered device handle, tears down the master bus
+ * if already instantiated, then toggles SCL manually to free slaves stuck in
+ * mid-transaction. Lines are left in input mode afterwards so the subsequent
+ * ::DEV_I2C_Init call can recreate the controller cleanly.
+ *
+ * @return esp_err_t ESP_OK when the recovery pulses have been generated,
+ *         or a propagated GPIO error.
+ */
+esp_err_t DEV_I2C_Bus_Recover(void);
+
+/**
  * @brief Probe an I2C address to verify device presence.
  *
  * @param addr 7-bit I2C address to probe.


### PR DESCRIPTION
## Summary
- add an I2C bus recovery helper that clocks SCL, rebuilds the master bus and invalidates cached device handles
- retry CH422G probing with the new recovery path so the expander and SD CS come back once the bus wiring is fixed
- document the automatic I²C recovery logic in the configuration section of the README

## Testing
- idf.py reconfigure *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1811f37c83239d4425c6428beabe