### PR TITLE
Fix storage component dependency on esp_mm

### DIFF
--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -2,4 +2,5 @@ idf_component_register(
     SRCS "sd_spi.c"
     INCLUDE_DIRS "include"
     REQUIRES driver vfs fatfs sdmmc ch422g
+    PRIV_REQUIRES esp_mm
 )


### PR DESCRIPTION
## Summary
- add the esp_mm dependency to the storage component's private requirements to provide esp_cache_private.h

## Testing
- ⚠️ `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf333ee10c8323b702d52e4711cda7