### PR TITLE
Fix storage component esp_timer dependency

### DIFF
--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -2,5 +2,5 @@ idf_component_register(
     SRCS "sd_spi.c"
     INCLUDE_DIRS "include"
     REQUIRES driver vfs fatfs sdmmc ch422g
-    PRIV_REQUIRES esp_mm
+    PRIV_REQUIRES esp_mm esp_timer
 )


### PR DESCRIPTION
## Summary
- declare esp_timer as a private requirement for the storage component so it can include esp_timer.h

## Testing
- ⚠️ `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3850b1808323911c1d97e9ba8902