### PR TITLE
Fix unmatched preprocessor directive in SD SPI driver

### DIFF
--- a/components/storage/sd_spi.c
+++ b/components/storage/sd_spi.c
@@ -801,7 +801,6 @@ static esp_err_t sdspi_ch422g_do_transaction(sdspi_dev_handle_t handle, sdmmc_co
     _lock_release(&s_ch422g_lock);
     return ret;
 }
-#endif
 
 bool sd_is_mounted(void)
 {


### PR DESCRIPTION
## Summary
- remove an extraneous `#endif` from `sd_spi.c` so the storage driver builds again

## Testing
- not run (ESP-IDF toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d047ac1c908323aca0fd841b507abb