### PR TITLE
Allow real mode to fall back to simulated sensors

### DIFF
--- a/components/env_control/env_control.c
+++ b/components/env_control/env_control.c
@@ -364,6 +364,7 @@ static void controller_timer_cb(TimerHandle_t timer)
     time_t now = time(NULL);
     struct tm tm_now = {0};
     localtime_r(&now, &tm_now);
+    bool fallback_mode = sensors_is_using_simulation_fallback();
     size_t available_channels = sensors_get_channel_count();
 
     xSemaphoreTake(s_ctrl.lock, portMAX_DELAY);
@@ -391,6 +392,11 @@ static void controller_timer_cb(TimerHandle_t timer)
         float temp = channel_valid ? sensors_read_temperature_channel(terr->cfg.sensor_channel) : NAN;
         float hum = channel_valid ? sensors_read_humidity_channel(terr->cfg.sensor_channel) : NAN;
         float lux = channel_valid ? sensors_read_lux_channel(terr->cfg.sensor_channel) : NAN;
+        if (fallback_mode) {
+            temp = NAN;
+            hum = NAN;
+            lux = NAN;
+        }
         terr->state.temperature_c = temp;
         terr->state.humidity_pct = hum;
         terr->state.light_lux = lux;

--- a/components/sensors/sensors.h
+++ b/components/sensors/sensors.h
@@ -3,6 +3,7 @@
 
 #include "esp_err.h"
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,6 +30,7 @@ float sensors_read_humidity_channel(size_t channel);
 float sensors_read_lux_channel(size_t channel);
 size_t sensors_get_channel_count(void);
 void sensors_deinit(void);
+bool sensors_is_using_simulation_fallback(void);
 
 #ifdef __cplusplus
 }

--- a/main/main.c
+++ b/main/main.c
@@ -343,6 +343,19 @@ static void menu_btn_real_cb(lv_event_t *e) {
       lv_obj_center(mbox);
       return;
     }
+    if (err != ESP_OK) {
+      lv_obj_t *mbox = lv_msgbox_create(NULL);
+      lv_msgbox_add_title(mbox, "Erreur");
+      char msg[96];
+      snprintf(msg,
+               sizeof(msg),
+               "Initialisation capteurs échouée (%s)",
+               esp_err_to_name(err));
+      lv_msgbox_add_text(mbox, msg);
+      lv_msgbox_add_close_button(mbox);
+      lv_obj_center(mbox);
+      return;
+    }
     err = reptile_actuators_init();
     if (err == ESP_ERR_NOT_FOUND) {
       sensors_deinit();
@@ -353,8 +366,31 @@ static void menu_btn_real_cb(lv_event_t *e) {
       lv_obj_center(mbox);
       return;
     }
+    if (err != ESP_OK) {
+      sensors_deinit();
+      lv_obj_t *mbox = lv_msgbox_create(NULL);
+      lv_msgbox_add_title(mbox, "Erreur");
+      char msg[96];
+      snprintf(msg,
+               sizeof(msg),
+               "Initialisation actionneurs échouée (%s)",
+               esp_err_to_name(err));
+      lv_msgbox_add_text(mbox, msg);
+      lv_msgbox_add_close_button(mbox);
+      lv_obj_center(mbox);
+      return;
+    }
     save_last_mode(APP_MODE_REAL);
     reptile_real_start(panel_handle, tp_handle);
+    if (sensors_is_using_simulation_fallback()) {
+      lv_obj_t *warn = lv_msgbox_create(NULL);
+      lv_msgbox_add_title(warn, "Attention");
+      lv_msgbox_add_text(warn,
+                         "Aucun capteur physique détecté.\n"
+                         "Lecture en mode simulation.");
+      lv_msgbox_add_close_button(warn);
+      lv_obj_center(warn);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add automatic switch to the simulated sensor driver when the real hardware probe returns ESP_ERR_NOT_FOUND and expose the fallback state
- mark environmental telemetry as invalid during fallback so control loops stay safe while UI continues to run
- surface detailed LVGL error dialogs and a warning message whenever the fallback mode is active

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d12c667a648323944ce5999d34c19f