### PR TITLE
Add missing esp_timer dependency to sd component

### DIFF
--- a/components/sd/CMakeLists.txt
+++ b/components/sd/CMakeLists.txt
@@ -1,6 +1,8 @@
 idf_component_register(
     SRCS "sd_spi.c"
     INCLUDE_DIRS "include"
+    PRIV_REQUIRES
+        esp_timer
     REQUIRES
         esp_driver_spi
         esp_driver_gpio


### PR DESCRIPTION
## Summary
- add the esp_timer component as a private dependency of the sd component to provide esp_timer.h during builds

## Testing
- idf.py reconfigure *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d525c50e988323bb70790dc5a02e98