### PR TITLE
Fix compile-time IO line mapping

### DIFF
--- a/components/gpio/gpio_real.c
+++ b/components/gpio/gpio_real.c
@@ -31,16 +31,24 @@ typedef struct {
     reptile_output_t uv;
 } reptile_channel_hw_t;
 
+enum {
+    HEAT_RES_LINE = WAVESHARE_IO_LINE_FROM_EXIO_CONST(HEAT_RES_EXIO),
+    WATER_PUMP_LINE = WAVESHARE_IO_LINE_FROM_EXIO_CONST(WATER_PUMP_EXIO),
+    TEST_HEATER_LINE = WAVESHARE_IO_LINE_FROM_EXIO_CONST(1),
+    TEST_PUMP_LINE = WAVESHARE_IO_LINE_FROM_EXIO_CONST(2),
+    TEST_UV_LINE = WAVESHARE_IO_LINE_FROM_EXIO_CONST(3),
+};
+
 static const reptile_channel_hw_t s_hw_map[] = {
     {
-        .heater = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = waveshare_io_line_from_exio(HEAT_RES_EXIO)},
-        .pump = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = waveshare_io_line_from_exio(WATER_PUMP_EXIO)},
+        .heater = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = HEAT_RES_LINE},
+        .pump = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = WATER_PUMP_LINE},
         .uv = {.bus = REPTILE_OUTPUT_GPIO, .active_high = true, .signal.gpio = LED_GPIO_PIN},
     },
     {
-        .heater = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = waveshare_io_line_from_exio(1)},
-        .pump = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = waveshare_io_line_from_exio(2)},
-        .uv = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = waveshare_io_line_from_exio(3)},
+        .heater = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = TEST_HEATER_LINE},
+        .pump = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = TEST_PUMP_LINE},
+        .uv = {.bus = REPTILE_OUTPUT_EXPANDER, .active_high = false, .signal.line = TEST_UV_LINE},
     },
 };
 
@@ -48,7 +56,7 @@ static const reptile_channel_hw_t s_hw_map[] = {
 static const reptile_output_t s_feed_output = {
     .bus = REPTILE_OUTPUT_EXPANDER,
     .active_high = false,
-    .signal.line = waveshare_io_line_from_exio(SERVO_FEED_EXIO),
+    .signal.line = WAVESHARE_IO_LINE_FROM_EXIO_CONST(SERVO_FEED_EXIO),
 };
 #else
 static const reptile_output_t s_feed_output = {

--- a/components/rgb_lcd_port/CMakeLists.txt
+++ b/components/rgb_lcd_port/CMakeLists.txt
@@ -1,4 +1,5 @@
-idf_component_register(SRCS "rgb_lcd_port.c" 
+idf_component_register(SRCS "rgb_lcd_port.c"
                         INCLUDE_DIRS "."
                         REQUIRES driver esp_lcd gpio i2c io_extension lvgl_port
+                        PRIV_REQUIRES waveshare_io
                         )

--- a/components/touch/CMakeLists.txt
+++ b/components/touch/CMakeLists.txt
@@ -2,4 +2,5 @@
 idf_component_register(SRCS "gt911.c" "touch.c"
                         INCLUDE_DIRS "."
                         REQUIRES driver esp_lcd i2c gpio io_extension rgb_lcd_port
+                        PRIV_REQUIRES waveshare_io
                     )

--- a/components/waveshare_io/include/waveshare_io.h
+++ b/components/waveshare_io/include/waveshare_io.h
@@ -37,9 +37,14 @@ esp_err_t waveshare_io_sd_deselect(void);
 #define WAVESHARE_IO_LINE_BACKLIGHT 2u
 #define WAVESHARE_IO_LINE_LCD_RST 3u
 
+#define WAVESHARE_IO_EXIO_DISABLED UINT8_MAX
+
+#define WAVESHARE_IO_LINE_FROM_EXIO_CONST(exio) \
+    ((uint8_t)(((exio) > 0u) ? ((exio) - 1u) : WAVESHARE_IO_EXIO_DISABLED))
+
 static inline uint8_t waveshare_io_line_from_exio(uint8_t exio)
 {
-    return (exio > 0u) ? (uint8_t)(exio - 1u) : UINT8_MAX;
+    return WAVESHARE_IO_LINE_FROM_EXIO_CONST(exio);
 }
 
 static inline bool waveshare_io_line_valid(uint8_t line)


### PR DESCRIPTION
## Summary
- add a reusable macro that converts CH422G EXIO indices to IO expander line IDs at compile time
- update the GPIO actuator map to rely on the compile-time macro so static initialisers remain valid
- declare the Waveshare IO component as a private requirement for the RGB LCD port and touch drivers so their headers resolve during the build

## Testing
- idf.py reconfigure *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d571c13cf48323bd0886f87d87bb90