### PR TITLE
Fix wait bus delay for Waveshare IO initialization

### DIFF
--- a/components/waveshare_io/waveshare_io.c
+++ b/components/waveshare_io/waveshare_io.c
@@ -28,7 +28,7 @@ static uint8_t s_ch422g_addr = 0;
 static void wait_bus_settle(void)
 {
     if (xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED) {
-        ets_delay_us(50 * 1000);
+        esp_rom_delay_us(50 * 1000);
     } else {
         vTaskDelay(pdMS_TO_TICKS(50));
     }


### PR DESCRIPTION
## Summary
- replace the deprecated `ets_delay_us` call with `esp_rom_delay_us` when waiting for the Waveshare IO bus to settle
- ensure the component compiles under ESP-IDF v5.5 where `ets_delay_us` is no longer available

## Testing
- unable to run `idf.py build` in this environment because the ESP-IDF tools are not installed


------
https://chatgpt.com/codex/tasks/task_e_68d5aa6c335883239d5a8f5430c9a82d