### PR TITLE
docs: clarify waveshare board support status

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -3,6 +3,14 @@
 ## Objectif
 Plateforme éducative simulant des terrariums réalistes sur carte Waveshare ESP32-S3-Touch-LCD-7B. Tout est virtuel (capteurs/actionneurs simulés) pour sensibiliser le public aux responsabilités légales et éthiques liées aux reptiles.
 
+## Compatibilité carte Waveshare ESP32-S3-Touch-LCD-7B
+- Résolution et timings : le BSP configure l'afficheur RGB parallèle en 16 bits avec une horloge PCLK de 16 MHz et une résolution 1024x600 conforme aux deux révisions ST7262 (rev. A) et AXS15231B (rev. B).
+- Sélection de la révision matérielle via `menuconfig` (choix entre rev. A et rev. B) modifiant automatiquement l'affectation des broches de l'afficheur, de la dalle tactile GT911 et du lecteur microSD.
+- Initialisation matérielle : les fonctions `bsp_display_init`, `bsp_touch_init` et `bsp_sdcard_init` sont actuellement des squelettes qui journalisent les étapes à réaliser. Il reste à intégrer les appels `esp_lcd_new_rgb_panel`, le pilote I2C GT911 et la pile SDMMC pour disposer d'une application totalement opérationnelle.
+- LVGL : la configuration par défaut prépare une tâche LVGL avec une pile de 8 kio et une période de tick de 5 ms (PSRAM obligatoire). L'intégration effective nécessite toujours l'appel à `esp_lvgl_port_init()` avant `lv_init()`.
+
+> 📌 **À faire pour un support complet :** implémenter le pilote LCD RGB (`esp_lcd_new_rgb_panel`), initialiser le contrôleur tactile GT911 (I2C) et monter le lecteur microSD via `esp_vfs_fat_sdmmc_mount`. Ces éléments sont indispensables avant de flasher sur la carte.
+
 ## Structure
 ```
 firmware/


### PR DESCRIPTION
## Summary
- add a dedicated section in the firmware README that details the Waveshare ESP32-S3-Touch-LCD-7B compatibility status, including resolution, pinout selection, and pending BSP work.

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d66a7974cc8323b7728452c79edeae