### PR TITLE
[GAP-000] Ajout de l'analyse initiale des gaps

### DIFF
--- a/GAPS.md
+++ b/GAPS.md
@@ -1,0 +1,12 @@
+# Gaps d'implémentation SimulRepile
+
+| Gap ID | Exigence (AGENTS.md) | État constaté | Action minimale proposée |
+| --- | --- | --- | --- |
+| GAP-001 | Architecture `/firmware/main/sim` complète (§Architecture) | `firmware/main/CMakeLists.txt` référence `sim/models.c` mais le fichier est absent, empêchant la compilation. | Ajouter `sim/models.c` avec les utilitaires de modèles (ex : helpers d’environnement) et l’enregistrer dans CMake. |
+| GAP-002 | Persistance : compléter `save_list_slots()`/`save_validate()` (§9) | `save_manager.c/.h` ne fournissent ni énumération des slots ni fonction de validation hors chargement. | Implémenter `save_manager_list_slots()` (scan + métadonnées) et `save_manager_validate_slot()` (lecture en-tête + CRC). |
+| GAP-003 | Persistance : tests Unity CRC/rollback/json (§9) | Aucun test unitaire n’existe pour `persist/` ; flux CRC/.bak non couverts. | Ajouter un composant de tests Unity ciblant `save_manager` (CRC, .bak de secours, sérialisation JSON). |
+| GAP-004 | I18N : chargement dynamique `/i18n/{fr,en,de,es}.json` (§Accessibilité & i18n) | `i18n_manager.c` ignore le chemin SD, renvoie des chaînes codées en dur sans parsing JSON. | Implémenter chargement JSON (ex : cJSON), cache en mémoire et bascule à chaud via `i18n_manager_set_language`. |
+| GAP-005 | Documents : lecteur TXT/HTML minimal (§Fonctionnalités) | `doc_reader.c` renvoie des stubs, ne liste ni ne lit réellement les fichiers SD. | Parcourir les dossiers par catégorie, filtrer extensions, lire contenu TXT/HTML (fallback texte). |
+| GAP-006 | Assets : cache LRU + backend SD (§Perf & robustesse) | `asset_cache.c` ne fait que journaliser sans stockage ni LRU. | Introduire un mini-cache (liste chaînée/queue) avec limite configurable, comptage références et lecture sur SD. |
+| GAP-007 | Kconfig : symboles APP/BSP (§9) | `sdkconfig.defaults` référence des `CONFIG_APP_*`/`CONFIG_BSP_*` inexistants faute de fichier `Kconfig`. | Ajouter `Kconfig`/sous-Kconfig définissant ces options (valeurs par défaut alignées). |
+| GAP-008 | MAJ par SD : parsing `manifest.json` + CRC/rollback (§MAJ & fiabilité) | Aucun module de mise à jour sur SD/OTA n’est présent dans `main/` ou `components/`. | Créer un module `updates` (lecture manifeste, vérification CRC, copie binaire + rollback .bak). |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,10 @@
+# Plan de traitement des gaps
+
+1. **GAP-001 – Compléter `sim/models.c`** : blocage de build immédiat, condition préalable à toute intégration continue.
+2. **GAP-007 – Introduire le Kconfig applicatif/BSP** : sans symboles déclarés, les options `CONFIG_APP_*`/`CONFIG_BSP_*` référencées restent inertes.
+3. **GAP-002 – Ajouter `save_manager_list_slots()`/`save_manager_validate_slot()`** : priorité persistance (AGENTS §9) afin de sécuriser les sauvegardes.
+4. **GAP-003 – Créer les tests Unity de persistance** : toujours dans le périmètre persistance, garantir CRC et rollback avant d’aller plus loin.
+5. **GAP-004 – Implémenter le chargement i18n JSON** : priorité suivante (Accessibilité & i18n) pour activer le multilingue dynamique.
+6. **GAP-005 – Finaliser le lecteur de documents** : dépend des précédents (accès fichiers + i18n pour les libellés) et débloque la navigation pédagogique.
+7. **GAP-006 – Mettre en place le cache d’assets LRU** : amélioration perf/robustesse après les fonctionnalités utilisateur critiques.
+8. **GAP-008 – Implémenter la mise à jour par carte SD** : dernière étape (MAJ & fiabilité) une fois le socle application stabilisé.


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §6) : "Scanner & rédiger GAPS.md" puis "Proposer PLAN.md".
- État initial : aucun fichier de suivi des gaps ni plan de traitement n'était versionné dans le dépôt.
- Motif du changement: gap confirmé (voir GAPS.md) — création des artefacts de pilotage.

Scope (strict)
- Ajouts/fichiers: `GAPS.md`, `PLAN.md`.
- Aucune suppression/renommage massif
- Aucun changement de format/contrat public existant

Implémentation
- Diffs clés: rédaction d'un tableau des exigences vs état, priorisation structurée des gaps.
- Choix techniques minimaux: simple Markdown pour compatibilité et revue aisée.

Tests
- Unitaires: N/A
- Manuels: Relecture statique du contenu Markdown.
- Résultats: N/A

Risques
- Compat: rétrocompat OK / migration N/A
- Perf: inchangée / mesurée

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d677242a2c8323ba30092adb5f4439