### PR TITLE
[GAP-001] Débloquer la compilation initiale

### DIFF
--- a/GAPS.md
+++ b/GAPS.md
@@ -1,0 +1,12 @@
+# Gaps d'implémentation SimulRepile
+
+| Gap ID | Exigence (AGENTS.md) | État constaté | Action minimale proposée |
+| --- | --- | --- | --- |
+| GAP-001 | Architecture `/firmware/main/sim` complète (§Architecture) | `firmware/main/CMakeLists.txt` référence `sim/models.c` mais le fichier est absent, empêchant la compilation. | Ajouter `sim/models.c` avec les utilitaires de modèles (ex : helpers d’environnement) et l’enregistrer dans CMake. |
+| GAP-002 | Persistance : compléter `save_list_slots()`/`save_validate()` (§9) | `save_manager.c/.h` ne fournissent ni énumération des slots ni fonction de validation hors chargement. | Implémenter `save_manager_list_slots()` (scan + métadonnées) et `save_manager_validate_slot()` (lecture en-tête + CRC). |
+| GAP-003 | Persistance : tests Unity CRC/rollback/json (§9) | Aucun test unitaire n’existe pour `persist/` ; flux CRC/.bak non couverts. | Ajouter un composant de tests Unity ciblant `save_manager` (CRC, .bak de secours, sérialisation JSON). |
+| GAP-004 | I18N : chargement dynamique `/i18n/{fr,en,de,es}.json` (§Accessibilité & i18n) | `i18n_manager.c` ignore le chemin SD, renvoie des chaînes codées en dur sans parsing JSON. | Implémenter chargement JSON (ex : cJSON), cache en mémoire et bascule à chaud via `i18n_manager_set_language`. |
+| GAP-005 | Documents : lecteur TXT/HTML minimal (§Fonctionnalités) | `doc_reader.c` renvoie des stubs, ne liste ni ne lit réellement les fichiers SD. | Parcourir les dossiers par catégorie, filtrer extensions, lire contenu TXT/HTML (fallback texte). |
+| GAP-006 | Assets : cache LRU + backend SD (§Perf & robustesse) | `asset_cache.c` ne fait que journaliser sans stockage ni LRU. | Introduire un mini-cache (liste chaînée/queue) avec limite configurable, comptage références et lecture sur SD. |
+| GAP-007 | Kconfig : symboles APP/BSP (§9) | `sdkconfig.defaults` référence des `CONFIG_APP_*`/`CONFIG_BSP_*` inexistants faute de fichier `Kconfig`. | Ajouter `Kconfig`/sous-Kconfig définissant ces options (valeurs par défaut alignées). |
+| GAP-008 | MAJ par SD : parsing `manifest.json` + CRC/rollback (§MAJ & fiabilité) | Aucun module de mise à jour sur SD/OTA n’est présent dans `main/` ou `components/`. | Créer un module `updates` (lecture manifeste, vérification CRC, copie binaire + rollback .bak). |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,10 @@
+# Plan de traitement des gaps
+
+1. **GAP-001 – Compléter `sim/models.c`** : blocage de build immédiat, condition préalable à toute intégration continue.
+2. **GAP-007 – Introduire le Kconfig applicatif/BSP** : sans symboles déclarés, les options `CONFIG_APP_*`/`CONFIG_BSP_*` référencées restent inertes.
+3. **GAP-002 – Ajouter `save_manager_list_slots()`/`save_manager_validate_slot()`** : priorité persistance (AGENTS §9) afin de sécuriser les sauvegardes.
+4. **GAP-003 – Créer les tests Unity de persistance** : toujours dans le périmètre persistance, garantir CRC et rollback avant d’aller plus loin.
+5. **GAP-004 – Implémenter le chargement i18n JSON** : priorité suivante (Accessibilité & i18n) pour activer le multilingue dynamique.
+6. **GAP-005 – Finaliser le lecteur de documents** : dépend des précédents (accès fichiers + i18n pour les libellés) et débloque la navigation pédagogique.
+7. **GAP-006 – Mettre en place le cache d’assets LRU** : amélioration perf/robustesse après les fonctionnalités utilisateur critiques.
+8. **GAP-008 – Implémenter la mise à jour par carte SD** : dernière étape (MAJ & fiabilité) une fois le socle application stabilisé.

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1,0 +1,83 @@
+menu "SimulRepile Application Configuration"
+
+config APP_MAX_TERRARIUMS
+    int "Maximum number of terrariums"
+    range 1 8
+    default 4
+    help
+        Defines how many terrariums can be simulated simultaneously.
+        Keep this value aligned with the UI layout (4 slots maximum).
+
+config APP_AUTOSAVE_INTERVAL_S
+    int "Autosave interval (seconds)"
+    range 30 3600
+    default 120
+    help
+        Interval between automatic persistence operations. Values below
+        30 seconds may impact SD throughput without benefit.
+
+config APP_ENABLE_COMPRESSION
+    bool "Enable save data compression"
+    default n
+    help
+        Activate the optional compression backend defined in
+        components/compression_if. Disable to simplify debugging of
+        JSON save payloads.
+
+config APP_ENABLE_WIFI_OTA
+    bool "Enable Wi-Fi OTA updates"
+    default n
+    help
+        Allow firmware upgrades through Wi-Fi in addition to SD card
+        based updates. Requires Wi-Fi credentials management.
+
+config APP_ENABLE_TTS_STUB
+    bool "Enable TTS stub"
+    default n
+    help
+        Provide a stub Text-To-Speech hook for accessibility testing.
+        Implementations can be swapped at runtime through the settings
+        screen.
+
+config APP_LANG_DEFAULT
+    string "Default language (ISO 639-1 code)"
+    default "fr"
+    help
+        ISO 639-1 language code loaded during the first boot. Users can
+        switch language at runtime through the settings screen.
+
+config APP_THEME_HIGH_CONTRAST
+    bool "Enable high-contrast theme by default"
+    default y
+    help
+        Enables the accessible color palette on first boot. Users may
+        revert to the standard theme from the settings screen.
+
+menu "Board Support Package Options"
+
+choice BSP_SD_BUS_WIDTH
+    prompt "SD bus width"
+    default BSP_SD_BUS_WIDTH_1BIT
+    help
+        Select the data bus width for the SD/MMC interface. 1-bit is the
+        safe default for wiring simplicity; 4-bit provides higher
+        throughput when all data lines are available.
+
+config BSP_SD_BUS_WIDTH_1BIT
+    bool "1-bit"
+
+config BSP_SD_BUS_WIDTH_4BIT
+    bool "4-bit"
+endchoice
+
+config BSP_USB_CAN_SELECTABLE
+    bool "Allow runtime USB/CAN selection"
+    default y
+    help
+        Exposes the CH422G EXIO5 line allowing the user to switch
+        between native USB (CDC) and CAN functionality from the
+        settings screen.
+
+endmenu
+
+endmenu

--- a/firmware/main/sim/models.c
+++ b/firmware/main/sim/models.c
@@ -1,0 +1,136 @@
+#include "sim/models.h"
+
+#include <math.h>
+#include <string.h>
+
+#include "esp_log.h"
+
+static const char *TAG = "sim_models";
+
+static float clampf(float value, float min_value, float max_value)
+{
+    if (value < min_value) {
+        return min_value;
+    }
+    if (value > max_value) {
+        return max_value;
+    }
+    return value;
+}
+
+void environment_profile_copy(environment_profile_t *dst, const environment_profile_t *src)
+{
+    if (!dst || !src) {
+        ESP_LOGW(TAG, "environment_profile_copy called with null pointer");
+        return;
+    }
+    memcpy(dst, src, sizeof(environment_profile_t));
+}
+
+void environment_profile_interpolate(const environment_profile_t *from,
+                                     const environment_profile_t *to,
+                                     float ratio,
+                                     environment_profile_t *out)
+{
+    if (!from || !to || !out) {
+        ESP_LOGW(TAG, "environment_profile_interpolate called with null pointer");
+        return;
+    }
+
+    float t = clampf(ratio, 0.0f, 1.0f);
+    out->temp_day_c = from->temp_day_c + (to->temp_day_c - from->temp_day_c) * t;
+    out->temp_night_c = from->temp_night_c + (to->temp_night_c - from->temp_night_c) * t;
+    out->humidity_day_pct = from->humidity_day_pct + (to->humidity_day_pct - from->humidity_day_pct) * t;
+    out->humidity_night_pct = from->humidity_night_pct + (to->humidity_night_pct - from->humidity_night_pct) * t;
+    out->lux_day = from->lux_day + (to->lux_day - from->lux_day) * t;
+    out->lux_night = from->lux_night + (to->lux_night - from->lux_night) * t;
+}
+
+void terrarium_state_init(terrarium_state_t *state,
+                          const reptile_profile_t *profile,
+                          uint32_t timestamp_seconds)
+{
+    if (!state) {
+        ESP_LOGE(TAG, "terrarium_state_init requires a valid state pointer");
+        return;
+    }
+
+    memset(state, 0, sizeof(*state));
+    state->profile = profile;
+
+    if (profile) {
+        environment_profile_copy(&state->current_environment, &profile->environment);
+    }
+
+    state->health.hydration_pct = 85.0f;
+    state->health.stress_pct = 12.0f;
+    state->health.health_pct = 95.0f;
+    state->health.last_feeding_timestamp = timestamp_seconds != TERRARIUM_INVALID_TIMESTAMP
+                                               ? timestamp_seconds
+                                               : TERRARIUM_INVALID_TIMESTAMP;
+    state->activity_score = 0.5f;
+}
+
+void terrarium_state_set_environment(terrarium_state_t *state, const environment_profile_t *environment)
+{
+    if (!state || !environment) {
+        ESP_LOGW(TAG, "terrarium_state_set_environment called with null pointer");
+        return;
+    }
+    environment_profile_copy(&state->current_environment, environment);
+}
+
+void terrarium_state_apply_environment(terrarium_state_t *state,
+                                       const environment_profile_t *target,
+                                       float smoothing_factor)
+{
+    if (!state || !target) {
+        ESP_LOGW(TAG, "terrarium_state_apply_environment called with null pointer");
+        return;
+    }
+
+    float factor = clampf(smoothing_factor, 0.0f, 1.0f);
+    environment_profile_t blended;
+    environment_profile_interpolate(&state->current_environment, target, factor, &blended);
+    environment_profile_copy(&state->current_environment, &blended);
+}
+
+void terrarium_state_record_feeding(terrarium_state_t *state, uint32_t timestamp_seconds)
+{
+    if (!state) {
+        ESP_LOGW(TAG, "terrarium_state_record_feeding called with null state");
+        return;
+    }
+    state->health.last_feeding_timestamp = timestamp_seconds;
+    state->health.hydration_pct = clampf(state->health.hydration_pct + 5.0f, 0.0f, 100.0f);
+    state->health.stress_pct = clampf(state->health.stress_pct - 3.0f, 0.0f, 100.0f);
+}
+
+uint32_t terrarium_state_time_since_feeding(const terrarium_state_t *state, uint32_t current_timestamp_seconds)
+{
+    if (!state) {
+        return 0;
+    }
+    if (state->health.last_feeding_timestamp == TERRARIUM_INVALID_TIMESTAMP) {
+        return 0;
+    }
+    if (current_timestamp_seconds <= state->health.last_feeding_timestamp) {
+        return 0;
+    }
+    return current_timestamp_seconds - state->health.last_feeding_timestamp;
+}
+
+bool terrarium_state_needs_feeding(const terrarium_state_t *state, uint32_t current_timestamp_seconds)
+{
+    if (!state || !state->profile || state->profile->feeding_interval_days == 0) {
+        return false;
+    }
+
+    uint32_t elapsed = terrarium_state_time_since_feeding(state, current_timestamp_seconds);
+    if (elapsed == 0) {
+        return false;
+    }
+
+    const uint64_t interval_seconds = (uint64_t)state->profile->feeding_interval_days * 24U * 60U * 60U;
+    return elapsed >= interval_seconds;
+}

--- a/firmware/main/sim/models.h
+++ b/firmware/main/sim/models.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -36,6 +37,25 @@ typedef struct {
     health_state_t health;
     float activity_score;
 } terrarium_state_t;
+
+#define TERRARIUM_INVALID_TIMESTAMP UINT32_C(0)
+
+void environment_profile_copy(environment_profile_t *dst, const environment_profile_t *src);
+void environment_profile_interpolate(const environment_profile_t *from,
+                                     const environment_profile_t *to,
+                                     float ratio,
+                                     environment_profile_t *out);
+
+void terrarium_state_init(terrarium_state_t *state,
+                          const reptile_profile_t *profile,
+                          uint32_t timestamp_seconds);
+void terrarium_state_set_environment(terrarium_state_t *state, const environment_profile_t *environment);
+void terrarium_state_apply_environment(terrarium_state_t *state,
+                                       const environment_profile_t *target,
+                                       float smoothing_factor);
+void terrarium_state_record_feeding(terrarium_state_t *state, uint32_t timestamp_seconds);
+uint32_t terrarium_state_time_since_feeding(const terrarium_state_t *state, uint32_t current_timestamp_seconds);
+bool terrarium_state_needs_feeding(const terrarium_state_t *state, uint32_t current_timestamp_seconds);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Architecture) : fournir le module `/firmware/main/sim/models.c` référencé par CMake pour les utilitaires de simulation.
- Exigence (AGENTS.md §9) : déclarer les symboles `CONFIG_APP_*` et `CONFIG_BSP_*` via Kconfig pour appliquer `sdkconfig.defaults`.
- État initial : `sim/models.c` absent (référence orpheline) et aucune définition Kconfig → build bloqué (`idf.py build` échoue avant compilation effective) et options ignorées.
- Motif du changement : gaps confirmés (voir GAPS.md).

Scope (strict)
- Ajouts/fichiers : `firmware/main/sim/models.c`, `firmware/main/Kconfig.projbuild`.
- Modifications ciblées : `firmware/main/sim/models.h` (prototypes manquants).
- Aucune suppression/renommage massif.
- Aucun changement de contrat public existant.

Implémentation
- Diffs clés : implémentation des helpers `environment_profile_*` et `terrarium_state_*` pour initialiser et piloter les profils simulés (réutilisables par `sim_engine`).
- Ajout du menu Kconfig applicatif/BSP (options autosave, compression, langue par défaut, largeur bus SD, sélection USB↔CAN) afin que `sdkconfig.defaults` soit pris en compte par `idf.py`.
- Journalisation ESP-IDF minimaliste pour sécuriser l’usage (warnings null pointer, etc.).

Tests
- Unitaires : N/A (nouveau code pur fonctions utilitaires, pas encore de harness Unity).
- Manuels : inspection statique des sources + vérification `git diff`.
- Résultats : N/A (environnement CI non disponible ici).

Risques
- Compat : rétrocompatibilité OK (ajout pur, structures inchangées).
- Perf : inchangée (helpers légers, aucune boucle coûteuse).

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d677242a2c8323ba30092adb5f4439