### PR TITLE
[GAP-005] Ajouter les dépendances manquantes au lecteur de documents

### DIFF
--- a/firmware/main/docs/doc_reader.c
+++ b/firmware/main/docs/doc_reader.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Fonctionnalités) : le module Documents doit parcourir les dossiers et filtrer les fichiers TXT/HTML.
- État initial (firmware/main/docs/doc_reader.c†L1-L20) : l'implémentation utilise qsort pour trier mais n'inclut pas l'en-tête standard correspondant, ce qui casse la compilation.
- Motif du changement : gap confirmé (voir GAPS.md) empêchant la construction.

Scope (strict)
- Ajouts/fichiers : firmware/main/docs/doc_reader.c (inclusion de <stdlib.h> pour qsort).
- Aucune suppression/renommage massif
- Aucun changement de format/contrat public existant

Implémentation
- Diffs clés : ajout de <stdlib.h> pour déclarer qsort et autres utilitaires standard.
- Choix techniques minimaux : dépendance standard du C, pas de logique supplémentaire.

Tests
- Unitaires : N/A (pas de harness disponible pour ce stub)
- Manuels : N/A
- Résultats : Compilation à refaire avec ESP-IDF (environnement requis)

Risques
- Compat : rétrocompat OK / migration N/A
- Perf : inchangée

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6925a14a88323a4fc6f117c6eee0f