### PR TITLE
[GAP-004] Corriger la dépendance cJSON du composant principal

### DIFF
--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -28,7 +28,7 @@ idf_component_register(
     REQUIRES
         lvgl_port
         compression_if
-        cjson
+        cJSON
 )
 
 # Add Unity tests placeholder component if needed later.


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Accessibilité & i18n): le chargeur i18n doit parser les catalogues JSON via cJSON.
- État initial (firmware/main/CMakeLists.txt L28-L32): la clause `REQUIRES` faisait référence au composant `cjson`, inexistant dans ESP-IDF ≥5.5, ce qui interrompait la configuration.
- Motif du changement: gap confirmé (voir GAPS.md, GAP-004).

Scope (strict)
- Ajouts/fichiers: firmware/main/CMakeLists.txt.
- Aucune suppression/renommage massif.
- Aucun changement de format/contrat public existant.

Implémentation
- Diffs clés: renommage de la dépendance de `cjson` vers `cJSON`, l’identifiant valide du composant ESP-IDF.
- Choix techniques minimaux: aucune autre modification CMake ; aucune dépendance additionnelle.

Tests
- Unitaires: N/A (changement CMake uniquement).
- Manuels: N/A (configuration CMake non rejouée dans cet environnement).
- Résultats: non exécutés (outil ESP-IDF absent sur le runner).

Risques
- Compat: rétrocompatibilité inchangée, la référence `cJSON` est le nom officiel.
- Perf: inchangée.

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6947e1aac8323bd010b676b0978b9