### PR TITLE
[GAP-004] Enregistrer la dépendance cJSON pour la localisation

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/cjson: "^1.0.0"


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Accessibilité & i18n): le module i18n doit charger les fichiers JSON depuis la carte SD, ce qui impose une bibliothèque JSON disponible dans le build.
- État initial: `firmware/main/CMakeLists.txt` déclare `cjson` dans `REQUIRES`, mais aucun manifeste `idf_component.yml` n'était fourni dans `main/`, rendant la dépendance introuvable par le Component Manager et bloquant `idf.py build`.
- Motif du changement: gap confirmé (voir GAPS.md GAP-004) — l’absence de déclaration empêchait toute avancée sur le chargement dynamique i18n.

Scope (strict)
- Ajouts/fichiers: `firmware/main/idf_component.yml`.
- Aucune suppression/renommage massif.
- Aucun changement de format/contrat public existant.

Implémentation
- Diffs clés: ajout d’un manifeste Component Manager pour `main`.
- Choix techniques minimaux: déclaration de la dépendance `espressif/cjson` en version compatible (`^1.0.0`).

Tests
- Unitaires: non exécutés (pas de couverture applicable à ce patch).
- Manuels: non exécutés (environnement container sans toolchain ESP-IDF complète).
- Résultats: N/A.

Risques
- Compat: rétrocompatibilité conservée (ajout de dépendance manquant).
- Perf: inchangée.

Checklist
- [x] Respect "Surgical-Only"
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6986abee48323a2a86cab6dc0ab71