### PR TITLE
[GAP-009] Fix IDF cJSON dependency reference

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,3 +1,3 @@
 dependencies:
   idf: ">=5.5"
-  idf::cjson: "*"
+  'idf::cjson': "*"


### PR DESCRIPTION
## Contexte
- Exigence (AGENTS.md §Build & configuration): les dépendances ESP-IDF doivent être correctement déclarées pour assurer la compilation minimale.
- État initial (firmware/main/idf_component.yml L2-L3): la dépendance `idf::cjson` était déclarée sans guillemets, provoquant l'échec du parseur de manifeste.
- Motif du changement: gap confirmé (voir GAPS.md)

## Scope (strict)
- Ajouts/fichiers: aucun fichier ajouté.
- Aucune suppression/renommage massif
- Aucun changement de format/contrat public existant

## Implémentation
- Diffs clés: guillemets ajoutés autour de la clé `idf::cjson` afin que le parser YAML l’interprète comme une chaîne.
- Choix techniques minimaux: modification d’une seule ligne pour lever l’erreur de nom de composant.

## Tests
- Unitaires: N/A (non applicables à ce correctif manifeste)
- Manuels: N/A (non applicables)
- Résultats: N/A

## Risques
- Compat: rétrocompatibilité OK ; la dépendance cible reste identique.
- Perf: inchangée

## Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6a0cadac48323834d933e14350b4d