### PR TITLE
[GAP-009] Corriger la dépendance cJSON

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf: ">=5.5"
-  "idf::cjson":
+  "idf::cJSON":
     version: "*"


### PR DESCRIPTION
## Contexte
- Exigence (AGENTS.md §Build & configuration): Le manifeste doit référencer les composants ESP-IDF officiels.
- État initial (référencer fichiers et lignes): `firmware/main/idf_component.yml` déclarait `idf::cjson`, ce qui provoquait l'échec de `idf.py build`.
- Motif du changement: gap confirmé (voir GAPS.md)

## Scope (strict)
- Ajouts/fichiers: aucun
- Aucune suppression/renommage massif
- Aucun changement de format/contrat public existant

## Implémentation
- Diffs clés: correction du nom du composant `cJSON` dans `idf_component.yml`.
- Choix techniques minimaux: alignement sur la casse officielle `idf::cJSON` fournie par ESP-IDF ≥ 5.5.

## Tests
- Unitaires: N/A
- Manuels: N/A
- Résultats: N/A

## Risques
- Compat: rétrocompat OK / migration N/A
- Perf: inchangée / mesurée

## Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6a489132483239b7fb3534afe2d72