### PR TITLE
[GAP-009] Corriger la dépendance cJSON vers le composant IDF natif

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
   idf: ">=5.5"
-  "idf::cJSON":
+  "idf::cjson":
     version: "*"


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Build & configuration): le manifeste doit référencer les composants ESP-IDF natifs pour garantir la résolution automatique des dépendances.
- État initial (main/idf_component.yml L3-L4): la dépendance était déclarée sous "idf::cJSON", ce qui rendait le champ invalide et bloquait `idf.py build`.
- Motif du changement: gap confirmé (voir GAPS.md, entrée GAP-009).

Scope (strict)
- Ajouts/fichiers: modification ciblée de `main/idf_component.yml`.
- Aucune suppression/renommage massif
- Aucun changement de format/contrat public existant

Implémentation
- Diffs clés: renommage de la dépendance vers `idf::cjson` pour alignement avec le registre IDF.
- Choix techniques minimaux: correction orthographique unique, sans introduction de dépendances externes.

Tests
- Unitaires: non applicables (simple correction de manifeste).
- Manuels: non exécutés (`idf.py` indisponible dans l'environnement conteneur standard).
- Résultats: N/A

Risques
- Compat: rétrocompat OK / migration N/A
- Perf: inchangée

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6a5b5bedc8323b0ca3420468a60a6