### PR TITLE
[GAP-009] Fix ESP-IDF manifest dependency

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,4 +1,2 @@
 dependencies:
   idf: ">=5.5"
-  "idf::cjson":
-    version: "*"


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Build & configuration): le manifeste de composant doit référencer correctement les dépendances ESP-IDF.
- État initial (firmware/main/idf_component.yml L3-L6): entrée `idf::cjson` invalide provoquant l'échec de `idf.py build`.
- Motif du changement: gap confirmé (voir GAPS.md, ligne GAP-009).

Scope (strict)
- Ajouts/fichiers: firmware/main/idf_component.yml.
- Aucune suppression/renommage massif.
- Aucun changement de format/contrat public existant.

Implémentation
- Suppression de l'entrée `idf::cjson` erronée pour aligner le manifeste sur les dépendances gérées par CMake (`REQUIRES cjson`).

Tests
- Unitaires: N/A (modification manifeste uniquement).
- Manuels: `idf.py build` non exécuté (toolchain non installée dans le conteneur CI).
- Résultats: N/A.

Risques
- Compat: rétrocompat OK (CMake continue d'exiger `cjson`).
- Perf: inchangée.

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6a6878130832388268c9563a93fd8