### PR TITLE
[GAP-009] Déclarer la dépendance cJSON côté composant main

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,2 +1,3 @@
 dependencies:
   idf: ">=5.5"
+  idf::cjson: "*"


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Build & configuration): le firmware doit se compiler avec ESP-IDF ≥ 5.5 et résoudre toutes les dépendances natives.
- État initial (firmware/main/CMakeLists.txt L27-L33 & firmware/main/idf_component.yml L1-L2): le composant `main` requiert `cjson` mais la dépendance n’est pas déclarée, provoquant l’échec `idf.py build`.
- Motif du changement: gap confirmé (voir GAPS.md, GAP-009).

Scope (strict)
- Ajouts/fichiers: firmware/main/idf_component.yml
- Aucune suppression/renommage massif
- Aucun changement de format/contrat public existant

Implémentation
- Diffs clés: ajout de la dépendance `idf::cjson` dans `idf_component.yml` pour tirer la version incluse dans ESP-IDF.
- Choix techniques minimaux: usage de la notation `idf::` pour viser le composant natif et conserver la compatibilité avec ESP-IDF 5.5+.

Tests
- Unitaires: N/A (changement de configuration uniquement).
- Manuels: idf.py build (non exécuté dans cet environnement conteneurisé dépourvu d’ESP-IDF toolchain).
- Résultats: N/A.

Risques
- Compat: rétrocompat OK (dépendance officielle ESP-IDF).
- Perf: inchangée.

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait

------
https://chatgpt.com/codex/tasks/task_e_68d6a8e909348323a6ce8c58ad8864d7