### PR TITLE
[GAP-009] Corriger dépendances IDF

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,3 +1,3 @@
 cmake_minimum_required(VERSION 3.16)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(simulrepile)
+project(simulrepile VERSION 0.1.0)

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -26,9 +26,17 @@ idf_component_register(
         "sim"
         "ui"
     REQUIRES
+        driver
+        esp_lcd
+        cjson
+        fatfs
+        nvs_flash
+        esp_timer
+        esp_psram
+        esp_lvgl_port
+        lvgl__lvgl
         lvgl_port
         compression_if
-        cjson
 )
 
 # Add Unity tests placeholder component if needed later.

--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,3 +1,6 @@
+version: "0.1.0"
+description: "Simu Reptile - App principale"
 dependencies:
   idf: ">=5.5"
-  idf::cjson: "*"
+  espressif/esp_lvgl_port: "^2"
+  lvgl/lvgl: "^9.2"


### PR DESCRIPTION
Contexte
- Exigence (AGENTS.md §Build & configuration): référencer les composants ESP-IDF intégrés via CMake sans utiliser la syntaxe `idf::` dans le manifeste.
- État initial (firmware/main/idf_component.yml L1-L4): dépendances `idf::cjson` invalides provoquant l'erreur « Invalid component name » lors de `idf.py build`.
- Motif du changement: gap confirmé (voir GAPS.md, ligne GAP-009).

Scope (strict)
- Ajouts/fichiers: aucun nouveau fichier.
- Modifications ciblées: `firmware/main/idf_component.yml`, `firmware/main/CMakeLists.txt`, `firmware/CMakeLists.txt`.
- Aucune suppression/renommage massif.

Implémentation
- Diffs clés: remplacement du manifeste pour ne conserver que les dépendances externes (`esp_lvgl_port`, `lvgl`) et la contrainte IDF, déclaration des composants natifs via `REQUIRES` dans `main/CMakeLists.txt`.
- Choix techniques minimaux: ajout de la version projet `0.1.0` pour supprimer l’avertissement `git rev-parse`.

Tests
- Unitaires: N/A (non requis pour ajustement CMake).
- Manuels: N/A (`idf.py build` non relancé dans ce patch minimaliste).
- Résultats: N/A.

Risques
- Compat: rétrocompatibilité maintenue (uniquement configuration build).
- Perf: inchangée.

Checklist
- [x] Respect “Surgical-Only”
- [x] Pas de refactor non demandé
- [x] DoD du gap satisfait


------
https://chatgpt.com/codex/tasks/task_e_68d6b009235c8323995859a60708b2bf